### PR TITLE
feat: text highlight for terminal

### DIFF
--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -3,12 +3,14 @@ package processor
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/boyter/cs/processor/snippet"
-	"github.com/fatih/color"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/boyter/cs/processor/printer"
+	"github.com/boyter/cs/processor/snippet"
+	"github.com/fatih/color"
 )
 
 func fileSummarize(input chan *FileJob) string {
@@ -38,10 +40,13 @@ func fileSummarize(input chan *FileJob) string {
 	})
 
 	for _, res := range results {
+		fmtBegin := "\033[1;31m"
+		fmtEnd := "\033[0m"
 		color.Magenta("%s (%.3f)", res.Location, res.Score)
 
 		locations := GetResultLocations(res)
-		rel := snippet.ExtractRelevant(string(res.Content), locations, int(SnippetLength), snippet.GetPrevCount(int(SnippetLength)), "…")
+		coloredContent := printer.WriteColored(res.Content, res.Locations, fmtBegin, fmtEnd)
+		rel := snippet.ExtractRelevant(coloredContent, locations, int(SnippetLength), snippet.GetPrevCount(int(SnippetLength)), "…")
 
 		fmt.Println(rel)
 

--- a/processor/printer/standard_test.go
+++ b/processor/printer/standard_test.go
@@ -14,6 +14,18 @@ func TestWriteColoredSimple(t *testing.T) {
 	}
 }
 
+func TestWriteColoredTermSimple(t *testing.T) {
+	loc := map[string][]int{}
+	loc["this"] = []int{0}
+
+	got := WriteColored([]byte("this"), loc, "\033[1;31m", "\033[0m")
+
+	expected := "\033[1;31mthis\033[0m"
+	if got != expected {
+		t.Error("Expected", expected, "got", got)
+	}
+}
+
 func TestWriteColoredCheckInOut(t *testing.T) {
 	loc := map[string][]int{}
 	loc["this"] = []int{0}


### PR DESCRIPTION
I have noticed that in the file standard_test.go, line 11 there is this piece of code
expected := "[red]this[white]"
which gets searched and executed in the terminal creating an impression of it being highlighted while searching for "expected"