### PR TITLE
Ignore hidden files and folder by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ cs
 
 # IDE
 .idea/
+.vscode
 
 sc.pprof

--- a/file/file.go
+++ b/file/file.go
@@ -10,6 +10,9 @@ import (
 	"sync"
 )
 
+// Include hidden files and directories in search
+var IncludeHidden = false
+
 var TerminateWalkError = errors.New("Walker terminated")
 
 type File struct {
@@ -134,6 +137,14 @@ func (f *FileWalker) walkDirectoryRecursive(directory string, ignores []gitignor
 			}
 		}
 
+		// Ignore hidden files
+		if !IncludeHidden {
+			shouldIgnore, err = IsHidden(file, directory)
+			if err != nil {
+				return err
+			}
+		}
+
 		if !shouldIgnore {
 			for _, p := range f.LocationExcludePattern {
 				if strings.Contains(filepath.Join(directory, file.Name()), p) {
@@ -162,6 +173,14 @@ func (f *FileWalker) walkDirectoryRecursive(directory string, ignores []gitignor
 		for _, deny := range f.PathDenylist {
 			if strings.HasSuffix(dir.Name(), deny) {
 				shouldIgnore = true
+			}
+		}
+
+		// Ignore hidden directories
+		if !IncludeHidden {
+			shouldIgnore, err = IsHidden(dir, directory)
+			if err != nil {
+				return err
 			}
 		}
 

--- a/file/hidden.go
+++ b/file/hidden.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package file
+
+import (
+	"os"
+)
+
+// IsHidden Returns true if file is hidden
+func IsHidden(file os.FileInfo, directory string) (bool, error) {
+	return file.Name()[0:1] == ".", nil
+}

--- a/file/hidden_windows.go
+++ b/file/hidden_windows.go
@@ -1,0 +1,23 @@
+// +build windows
+
+package file
+
+import (
+	"os"
+	"path"
+	"syscall"
+)
+
+// IsHidden Returns true if file is hidden
+func IsHidden(file os.FileInfo, directory string) (bool, error) {
+	fullpath := path.Join(directory, file.Name())
+	pointer, err := syscall.UTF16PtrFromString(fullpath)
+	if err != nil {
+		return false, err
+	}
+	attributes, err := syscall.GetFileAttributes(pointer)
+	if err != nil {
+		return false, err
+	}
+	return attributes&syscall.FILE_ATTRIBUTE_HIDDEN != 0, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/boyter/cs/file"
 	"github.com/boyter/cs/processor"
 	sccprocessor "github.com/boyter/scc/processor"
 	"github.com/spf13/cobra"
@@ -121,6 +122,12 @@ func main() {
 		"include-min",
 		false,
 		"include minified files",
+	)
+	flags.BoolVar(
+		&file.IncludeHidden,
+		"include-hidden",
+		false,
+		"include hidden files",
 	)
 	flags.IntVar(
 		&processor.MinifiedLineByteLength,


### PR DESCRIPTION
## Description

Related to issue #4 

Implemented cross platform (tested on windows and linux, should work on macos as well as the way of hiding files is the same as other *nix systems) way of excluding hidden files from the search tree.

By default the hidden files are excluded, but they can be brought back via the `--include-hidden` command line switch.

I had to implement the `IsHidden` function in a separate file in the `file` package to be able to use build tags, that are needed as the Windows implementation does not compile under Linux. A conditional on GOOS was not enough.

### Points of discussion

- `--include-hidden` could be more simply `--hidden`, shorter but less explicit
- `--include-hidden` does not have a shorthand, as `-h` is used for help, and `-.` did not seem to be too intuitive

### Notes

I tested this by copying the implementation in `processor.file`, because as of now `file.file` is not in use