### PR TITLE
Use the initialized IncludeHidden bool in NewFileWalker

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -49,7 +49,7 @@ func NewFileWalker(directory string, fileListQueue chan *File) FileWalker {
 		LocationExcludePattern: []string{},
 		PathExclude:            []string{},
 		EnableIgnoreFile:       false,
-		IncludeHidden:          false,
+		IncludeHidden:          IncludeHidden,
 	}
 }
 


### PR DESCRIPTION
Related to #4, initialize the `FileWalker.IgnoreHidden` with the right value. Currently the hidden files are never ignored.