### PR TITLE
Add Vimgrep format

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func main() {
 		"format",
 		"f",
 		"text",
-		"set output format [text, json]",
+		"set output format [text, json, vimgrep]",
 	)
 	flags.StringVar(
 		&processor.Ranker,


### PR DESCRIPTION
Provide option for integration with vim's grep command. This allows the
results to return to the Quickfix list and be cycled through after a
search.