### PR TITLE
HTTP search UI: real-time search, stable layout, and template refactor

### DIFF
--- a/asset/templates/bare/search.html
+++ b/asset/templates/bare/search.html
@@ -1,78 +1,51 @@
-<html>
-	<head>
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<title>{{ .SearchTerm }}</title>
-		<style>
-			strong {
-				background-color: #FFFF00;
-			}
-			pre {
-				white-space: pre-wrap;
-				white-space: -moz-pre-wrap;
-				white-space: -pre-wrap;
-				white-space: -o-pre-wrap;
-				word-wrap: break-word;
-			}
-			body {
-				width: 80%;
-				margin: 10px auto;
-				display: block;
-			}
-		</style>
-	</head>
-	<body>
-		<div>
-		<form method="get" action="/" >
-			<input type="text" name="q" value="{{ .SearchTerm }}" autofocus="autofocus" onfocus="this.select()" />
-			<input type="submit" value="search" />
-			<select name="ss" id="ss" onchange="this.form.submit()">
-				<option value="100" {{ if eq .SnippetSize 100 }}selected{{ end }}>100</option>
-				<option value="200" {{ if eq .SnippetSize 200 }}selected{{ end }}>200</option>
-				<option value="300" {{ if eq .SnippetSize 300 }}selected{{ end }}>300</option>
-				<option value="400" {{ if eq .SnippetSize 400 }}selected{{ end }}>400</option>
-				<option value="500" {{ if eq .SnippetSize 500 }}selected{{ end }}>500</option>
-				<option value="600" {{ if eq .SnippetSize 600 }}selected{{ end }}>600</option>
-				<option value="700" {{ if eq .SnippetSize 700 }}selected{{ end }}>700</option>
-				<option value="800" {{ if eq .SnippetSize 800 }}selected{{ end }}>800</option>
-				<option value="900" {{ if eq .SnippetSize 900 }}selected{{ end }}>900</option>
-				<option value="1000" {{ if eq .SnippetSize 1000 }}selected{{ end }}>1000</option>
-			</select>
-			<small>[{{ .ResultsCount }} results from {{ .ProcessedFileCount }} files in {{ .RuntimeMilliseconds }} (ms)]</small>
-		</form>
-		</div>
-		<div style="display:flex;">
-			{{if .Results -}}
-			<div style="flex-grow: 4;">
-				<ul>
-					{{- range .Results }}
-					<li>
-						<h4><a href="/file/{{ .Location }}?sp={{ .StartPos }}&ep={{ .EndPos }}">{{ .Title }}</a>{{ if .Language }} <small>({{ .Language }})</small>{{ end }}</h4>
-						{{ if .Lines }}<small style="color:#808080">{{ .Language }} | Lines: {{ .Lines }} | Code: {{ .Code }} | Comment: {{ .Comment }} | Blank: {{ .Blank }} | Complexity: {{ .Complexity }}</small>{{ end }}
-						{{ if .IsLineMode }}<pre>{{ range .LineResults }}<span style="color:#808080;user-select:none">{{ printf "%4d " .LineNumber }}</span>{{ .Content }}
-{{ end }}</pre>{{ else }}{{- range .Content }}
-							<pre>{{ . }}</pre>
-						{{- end }}{{ end }}
-					</li><small>[<a href="/file/{{ .Location }}?sp={{ .StartPos }}&ep={{ .EndPos }}#{{ .StartPos }}">jump to location</a>]</small>
-					{{- end }}
-				</ul>
-
-				<div>
-				{{- range .Pages }}
-					<a href="/?q={{ .SearchTerm }}&ss={{ .SnippetSize }}&p={{ .Value }}&ext={{ .Ext }}">{{ .Name }}</a>
-				{{- end }}
-				</div>
-			</div>
-			{{- end}}
-			{{if .ExtensionFacet }}
-			<div style="flex-grow: 1;">
-				<h4>extensions</h4>
-				<ol>
-				{{- range .ExtensionFacet }}
-					<li value="{{ .Count }}"><a href="/?q={{ .SearchTerm }}&ss={{ .SnippetSize }}&ext={{ .Title }}">{{ .Title }}</a></li>
-				{{- end }}
-				</ol>
-			</div>
-			{{- end }}
-		</div>
-	</body>
-</html>
+{{ define "searchStyles" }}<style>
+strong { background-color: #FFFF00; }
+strong strong { background-color: #FFFF00; }
+pre, .cs-result-linepre, .cs-snippet { white-space: pre-wrap; white-space: -moz-pre-wrap; white-space: -pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word; }
+.cs-search-body {
+	width: 80%;
+	margin: 10px auto;
+	display: block;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+	line-height: 1.5;
+	overflow-y: scroll;
+	min-height: 100vh;
+}
+.cs-search-form {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+.cs-search-input { flex: 1; min-width: 0; flex: 1 1 auto; }
+.cs-search-submit { flex: 0 0 auto; }
+.cs-search-select { flex: 0 0 auto; }
+.cs-stats {
+	color: inherit;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	font-variant-numeric: tabular-nums;
+	flex: 0 0 24ch;
+	min-width: 24ch;
+}
+.cs-results-layout { display: flex; }
+.cs-results-main { flex-grow: 1; min-width: 0; }
+.cs-results-sidebar { flex: 0 0 14rem; min-width: 14rem; }
+.cs-result-item {
+	padding: 10px 0;
+	border-bottom: 1px solid #ddd;
+}
+.cs-result-item h4 { margin: 0; }
+.cs-result-item h4 a { color: #0000EE; }
+.cs-result-item pre,
+.cs-result-linepre,
+.cs-snippet { background: inherit; }
+.cs-result-language { color: #808080; }
+.cs-result-meta { color: #808080; }
+.cs-result-lineno { color: #808080; user-select: none; }
+.cs-facet-list { padding-left: 24px; margin: 0; }
+.cs-facet-list li {
+	padding: 3px 0;
+}
+</style>{{ end }}

--- a/asset/templates/base/search.html
+++ b/asset/templates/base/search.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>{{ .SearchTerm }} - cs search</title>
+	{{ template "searchStyles" . }}
+</head>
+<body class="cs-search-body">
+	<div class="cs-container">
+		<form class="cs-search-form" method="get" action="/">
+			<input class="cs-search-input" type="text" name="q" value="{{ .SearchTerm }}" autofocus="autofocus" onfocus="this.select()" placeholder="Search..." />
+			<input class="cs-search-submit" type="submit" value="{{ if eq .TemplateStyle "bare" }}search{{ else }}Search{{ end }}" />
+			<select class="cs-search-select" name="ss" id="ss" onchange="this.form.submit()">
+				<option value="100" {{ if eq .SnippetSize 100 }}selected{{ end }}>100</option>
+				<option value="200" {{ if eq .SnippetSize 200 }}selected{{ end }}>200</option>
+				<option value="300" {{ if eq .SnippetSize 300 }}selected{{ end }}>300</option>
+				<option value="400" {{ if eq .SnippetSize 400 }}selected{{ end }}>400</option>
+				<option value="500" {{ if eq .SnippetSize 500 }}selected{{ end }}>500</option>
+				<option value="600" {{ if eq .SnippetSize 600 }}selected{{ end }}>600</option>
+				<option value="700" {{ if eq .SnippetSize 700 }}selected{{ end }}>700</option>
+				<option value="800" {{ if eq .SnippetSize 800 }}selected{{ end }}>800</option>
+				<option value="900" {{ if eq .SnippetSize 900 }}selected{{ end }}>900</option>
+				<option value="1000" {{ if eq .SnippetSize 1000 }}selected{{ end }}>1000</option>
+			</select>
+			<span id="cs-stats" class="cs-stats">[{{ .ResultsCount }} results from {{ .ProcessedFileCount }} files in {{ .RuntimeMilliseconds }} ms]</span>
+		</form>
+
+			<div id="cs-results" class="cs-results-layout">
+				{{if .Results -}}
+				<div class="cs-results-main">
+					{{- range .Results }}
+					<div class="cs-result-item">
+						<h4><a href="/file/{{ .Location }}?sp={{ .StartPos }}&ep={{ .EndPos }}">{{ .Title }}</a>{{ if .Language }} <span class="cs-result-language">({{ .Language }})</span>{{ end }}</h4>
+						{{ if .Lines }}<div class="cs-result-meta">{{ .Language }} | Lines: {{ .Lines }} | Code: {{ .Code }} | Comment: {{ .Comment }} | Blank: {{ .Blank }} | Complexity: {{ .Complexity }}</div>{{ end }}
+						{{ if .IsLineMode }}<pre class="cs-result-linepre">{{ range .LineResults }}<span class="cs-result-lineno">{{ printf "%4d " .LineNumber }}</span>{{ .Content }}
+{{ end }}</pre>{{ else }}{{- range .Content }}
+						<pre class="cs-snippet">{{ . }}</pre>
+						{{- end }}{{ end }}
+						<span class="cs-jump-link">[<a href="/file/{{ .Location }}?sp={{ .StartPos }}&ep={{ .EndPos }}#{{ .StartPos }}">jump to match</a>]</span>
+					</div>
+					{{- end }}
+
+					<div class="cs-pages">
+					{{- range .Pages }}
+						<a href="/?q={{ .SearchTerm }}&ss={{ .SnippetSize }}&p={{ .Value }}&ext={{ .Ext }}">{{ .Name }}</a>
+					{{- end }}
+					</div>
+					</div>
+					<div class="cs-results-sidebar">
+						{{if .ExtensionFacet }}
+							<div class="cs-sidebar-heading">Extensions</div>
+							<ul class="cs-facet-list">
+						{{- range .ExtensionFacet }}
+							<li><a href="/?q={{ .SearchTerm }}&ss={{ .SnippetSize }}&ext={{ .Title }}">{{ .Title }}</a> <span class="cs-facet-count">({{ .Count }})</span></li>
+						{{- end }}
+						</ul>
+						{{- end }}
+					</div>
+					{{- end}}
+				</div>
+	</div>
+	<script>
+		(function () {
+			var searchForm = document.querySelector('form[method="get"][action="/"]');
+			if (!searchForm) {
+				return;
+			}
+			var queryInput = searchForm.querySelector('input[name="q"]');
+			if (!queryInput) {
+				return;
+			}
+			var resultsContainer = document.getElementById('cs-results');
+			var statsElement = document.getElementById('cs-stats');
+
+			if (!resultsContainer || !statsElement) {
+				return;
+			}
+
+			var timer;
+			var lastQuery = queryInput.value;
+			var inFlight;
+			var parser = new DOMParser();
+			var delayMs = 50;
+			var doSearch = function () {
+				var nextQuery = queryInput.value;
+				if (nextQuery === lastQuery) {
+					return;
+				}
+				lastQuery = nextQuery;
+				clearTimeout(timer);
+				timer = setTimeout(function () {
+					var params = new URLSearchParams(new FormData(searchForm));
+					params.set('q', nextQuery);
+					params.delete('p');
+					params.set('_ajax', '1');
+
+					if (inFlight) {
+						inFlight.abort();
+					}
+					inFlight = new AbortController();
+					var requestUrl = '/?' + params.toString();
+
+					fetch(requestUrl, {
+						method: 'GET',
+						signal: inFlight.signal,
+					}).then(function (response) {
+						if (!response.ok) {
+							throw new Error('search request failed');
+						}
+						return response.text();
+					}).then(function (responseHTML) {
+						if (inFlight.signal.aborted) {
+							return;
+						}
+
+						var doc = parser.parseFromString(responseHTML, 'text/html');
+						var newResults = doc.getElementById('cs-results');
+						var newStats = doc.getElementById('cs-stats');
+
+						if (newResults) {
+							resultsContainer.innerHTML = newResults.innerHTML;
+						} else {
+							resultsContainer.innerHTML = '';
+						}
+
+						if (newStats) {
+							statsElement.innerHTML = newStats.innerHTML;
+						}
+
+						params.delete('_ajax');
+						if (history.replaceState) {
+							var nextLocation = '/';
+							var nextQuery = params.toString();
+							if (nextQuery) {
+								nextLocation = nextLocation + '?' + nextQuery;
+							}
+							history.replaceState({}, '', nextLocation);
+						}
+					}).catch(function (err) {
+						if (err && err.name === 'AbortError') {
+							return;
+						}
+						console.error('search request failed', err);
+					});
+				}, delayMs);
+			};
+
+			queryInput.addEventListener('input', doSearch);
+		})();
+	</script>
+</body>
+</html>

--- a/asset/templates/dark/search.html
+++ b/asset/templates/dark/search.html
@@ -1,172 +1,122 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>{{ .SearchTerm }} - cs search</title>
-	<style>
-		*, *::before, *::after { box-sizing: border-box; }
-		body {
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-			background: #1e1e1e;
-			color: #d4d4d4;
-			margin: 0;
-			padding: 20px;
-			line-height: 1.5;
-		}
-		.container { max-width: 960px; margin: 0 auto; }
-		h1 { font-size: 1.4em; margin: 0 0 16px 0; color: #e0e0e0; }
-		a { color: #569cd6; text-decoration: none; }
-		a:hover { text-decoration: underline; }
-		form {
-			display: flex;
-			gap: 8px;
-			align-items: center;
-			flex-wrap: wrap;
-			margin-bottom: 16px;
-		}
-		input[type="text"] {
-			flex: 1;
-			min-width: 200px;
-			padding: 8px 12px;
-			background: #3c3c3c;
-			border: 1px solid #555;
-			border-radius: 4px;
-			color: #d4d4d4;
-			font-size: 14px;
-		}
-		input[type="text"]:focus { outline: none; border-color: #569cd6; }
-		input[type="submit"] {
-			padding: 8px 16px;
-			background: #264f78;
-			border: 1px solid #3a7cc6;
-			border-radius: 4px;
-			color: #fff;
-			cursor: pointer;
-			font-size: 14px;
-		}
-		input[type="submit"]:hover { background: #365f8a; }
-		select {
-			padding: 8px;
-			background: #3c3c3c;
-			border: 1px solid #555;
-			border-radius: 4px;
-			color: #d4d4d4;
-			font-size: 14px;
-		}
-		.stats { color: #808080; font-size: 13px; }
-		.results-layout { display: flex; gap: 24px; }
-		.results-main { flex: 4; min-width: 0; }
-		.results-sidebar { flex: 1; min-width: 150px; }
-		.result-item {
-			padding: 12px 0;
-			border-bottom: 1px solid #333;
-		}
-		.result-item h4 { margin: 0 0 4px 0; font-size: 14px; font-weight: normal; }
-		.result-item h4 a { color: #569cd6; }
-		.result-item pre {
-			margin: 8px 0 4px 0;
-			padding: 10px;
-			background: #0d1117;
-			border-radius: 4px;
-			font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas", monospace;
-			font-size: 13px;
-			color: #c9d1d9;
-			white-space: pre-wrap;
-			word-wrap: break-word;
-			overflow-x: auto;
-		}
-		.result-item strong {
-			background: #6b4c00;
-			color: #ffd700;
-			padding: 1px 2px;
-			border-radius: 2px;
-		}
-		.jump-link { font-size: 12px; color: #808080; }
-		.jump-link a { color: #808080; }
-		.jump-link a:hover { color: #569cd6; }
-		.sidebar-heading {
-			font-size: 13px;
-			text-transform: uppercase;
-			letter-spacing: 0.5px;
-			color: #808080;
-			margin: 0 0 8px 0;
-			padding-bottom: 6px;
-			border-bottom: 1px solid #333;
-		}
-		.facet-list { list-style: none; padding: 0; margin: 0; }
-		.facet-list li {
-			padding: 3px 0;
-			font-size: 13px;
-		}
-		.facet-list a { color: #d4d4d4; }
-		.facet-list a:hover { color: #569cd6; }
-		.facet-count { color: #808080; font-size: 12px; }
-		.pages { padding: 16px 0; }
-		.pages a {
-			display: inline-block;
-			padding: 4px 10px;
-			margin-right: 4px;
-			background: #3c3c3c;
-			border-radius: 4px;
-			font-size: 13px;
-		}
-		.pages a:hover { background: #4c4c4c; }
-	</style>
-</head>
-<body>
-	<div class="container">
-		<form method="get" action="/">
-			<input type="text" name="q" value="{{ .SearchTerm }}" autofocus="autofocus" onfocus="this.select()" placeholder="Search..." />
-			<input type="submit" value="Search" />
-			<select name="ss" id="ss" onchange="this.form.submit()">
-				<option value="100" {{ if eq .SnippetSize 100 }}selected{{ end }}>100</option>
-				<option value="200" {{ if eq .SnippetSize 200 }}selected{{ end }}>200</option>
-				<option value="300" {{ if eq .SnippetSize 300 }}selected{{ end }}>300</option>
-				<option value="400" {{ if eq .SnippetSize 400 }}selected{{ end }}>400</option>
-				<option value="500" {{ if eq .SnippetSize 500 }}selected{{ end }}>500</option>
-				<option value="600" {{ if eq .SnippetSize 600 }}selected{{ end }}>600</option>
-				<option value="700" {{ if eq .SnippetSize 700 }}selected{{ end }}>700</option>
-				<option value="800" {{ if eq .SnippetSize 800 }}selected{{ end }}>800</option>
-				<option value="900" {{ if eq .SnippetSize 900 }}selected{{ end }}>900</option>
-				<option value="1000" {{ if eq .SnippetSize 1000 }}selected{{ end }}>1000</option>
-			</select>
-			<span class="stats">[{{ .ResultsCount }} results from {{ .ProcessedFileCount }} files in {{ .RuntimeMilliseconds }} ms]</span>
-		</form>
-
-		<div class="results-layout">
-			{{if .Results -}}
-			<div class="results-main">
-				{{- range .Results }}
-				<div class="result-item">
-					<h4><a href="/file/{{ .Location }}?sp={{ .StartPos }}&ep={{ .EndPos }}">{{ .Title }}</a>{{ if .Language }} <span style="color:#808080;font-size:12px">({{ .Language }})</span>{{ end }}</h4>
-					{{ if .Lines }}<div class="stats">{{ .Language }} | Lines: {{ .Lines }} | Code: {{ .Code }} | Comment: {{ .Comment }} | Blank: {{ .Blank }} | Complexity: {{ .Complexity }}</div>{{ end }}
-					{{ if .IsLineMode }}<pre>{{ range .LineResults }}<span style="color:#808080;user-select:none">{{ printf "%4d " .LineNumber }}</span>{{ .Content }}
-{{ end }}</pre>{{ else }}{{- range .Content }}
-					<pre>{{ . }}</pre>
-					{{- end }}{{ end }}
-					<span class="jump-link">[<a href="/file/{{ .Location }}?sp={{ .StartPos }}&ep={{ .EndPos }}#{{ .StartPos }}">jump to match</a>]</span>
-				</div>
-				{{- end }}
-
-				<div class="pages">
-				{{- range .Pages }}
-					<a href="/?q={{ .SearchTerm }}&ss={{ .SnippetSize }}&p={{ .Value }}&ext={{ .Ext }}">{{ .Name }}</a>
-				{{- end }}
-				</div>
-			</div>
-			{{- end}}
-			{{if .ExtensionFacet }}
-			<div class="results-sidebar">
-				<div class="sidebar-heading">Extensions</div>
-				<ul class="facet-list">
-				{{- range .ExtensionFacet }}
-					<li><a href="/?q={{ .SearchTerm }}&ss={{ .SnippetSize }}&ext={{ .Title }}">{{ .Title }}</a> <span class="facet-count">({{ .Count }})</span></li>
-				{{- end }}
-				</ul>
-			</div>
-			{{- end }}
-		</div>
-	</div>
-</body>
-</html>
+{{ define "searchStyles" }}<style>
+*, *::before, *::after { box-sizing: border-box; }
+.cs-search-body {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+	background: #1e1e1e;
+	color: #d4d4d4;
+	margin: 0;
+	padding: 20px;
+	line-height: 1.5;
+	overflow-y: scroll;
+	min-height: 100vh;
+}
+.cs-container { max-width: 960px; margin: 0 auto; }
+.cs-search-form { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 16px; }
+.cs-search-input {
+	padding: 8px 12px;
+	background: #3c3c3c;
+	border: 1px solid #555;
+	border-radius: 4px;
+	color: #d4d4d4;
+	font-size: 14px;
+	min-width: 0;
+	flex: 1 1 auto;
+}
+.cs-search-input:focus { outline: none; border-color: #569cd6; }
+.cs-search-submit {
+	padding: 8px 16px;
+	background: #264f78;
+	border: 1px solid #3a7cc6;
+	border-radius: 4px;
+	color: #fff;
+	cursor: pointer;
+	font-size: 14px;
+	flex: 0 0 auto;
+}
+.cs-search-submit:hover { background: #365f8a; }
+.cs-search-select {
+	padding: 8px;
+	background: #3c3c3c;
+	border: 1px solid #555;
+	border-radius: 4px;
+	color: #d4d4d4;
+	font-size: 14px;
+	flex: 0 0 auto;
+}
+.cs-stats {
+	color: #808080;
+	font-size: 13px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	font-variant-numeric: tabular-nums;
+	flex: 0 0 24ch;
+	min-width: 24ch;
+}
+a { color: #569cd6; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.cs-results-layout { display: flex; gap: 24px; }
+.cs-results-main { flex: 4; min-width: 0; }
+.cs-results-sidebar { flex: 0 0 14rem; min-width: 14rem; }
+.cs-result-item {
+	padding: 12px 0;
+	border-bottom: 1px solid #333;
+}
+.cs-result-item h4 { margin: 0 0 4px 0; font-size: 14px; font-weight: normal; }
+.cs-result-item h4 a { color: #569cd6; }
+.cs-result-item pre {
+	margin: 8px 0 4px 0;
+	padding: 10px;
+	background: #0d1117;
+	border-radius: 4px;
+	font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas", monospace;
+	font-size: 13px;
+	color: #c9d1d9;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	overflow-x: auto;
+}
+.cs-snippet { margin: 8px 0 4px 0; padding: 10px; background: #0d1117; border-radius: 4px; font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas", monospace; font-size: 13px; color: #c9d1d9; white-space: pre-wrap; word-wrap: break-word; overflow-x: auto; }
+.cs-result-linepre { margin: 8px 0 4px 0; padding: 10px; background: #0d1117; border-radius: 4px; font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas", monospace; font-size: 13px; color: #c9d1d9; white-space: pre-wrap; word-wrap: break-word; overflow-x: auto; }
+.cs-result-item strong {
+	background: #6b4c00;
+	color: #ffd700;
+	padding: 1px 2px;
+	border-radius: 2px;
+}
+.cs-result-language,
+.cs-result-meta { color: #808080; }
+.cs-result-language { font-size: 12px; }
+.cs-result-meta { margin: 4px 0; }
+.cs-jump-link { font-size: 12px; color: #808080; }
+.cs-jump-link a { color: #808080; }
+.cs-jump-link a:hover { color: #569cd6; }
+.cs-sidebar-heading {
+	font-size: 13px;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: #808080;
+	margin: 0 0 8px 0;
+	padding-bottom: 6px;
+	border-bottom: 1px solid #333;
+}
+.cs-facet-list { list-style: none; padding: 0; margin: 0; }
+.cs-facet-list li {
+	padding: 3px 0;
+	font-size: 13px;
+}
+.cs-facet-list a { color: #d4d4d4; }
+.cs-facet-list a:hover { color: #569cd6; }
+.cs-facet-count { color: #808080; font-size: 12px; }
+.cs-pages { padding: 16px 0; }
+.cs-pages a {
+	display: inline-block;
+	padding: 4px 10px;
+	margin-right: 4px;
+	background: #3c3c3c;
+	border-radius: 4px;
+	font-size: 13px;
+}
+.cs-pages a:hover { background: #4c4c4c; }
+.cs-result-lineno { color: #808080; user-select: none; }
+</style>{{ end }}

--- a/asset/templates/light/search.html
+++ b/asset/templates/light/search.html
@@ -1,176 +1,119 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>{{ .SearchTerm }} - cs search</title>
-	<style>
-		*, *::before, *::after { box-sizing: border-box; }
-		body {
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-			background: #fff;
-			color: #24292f;
-			margin: 0;
-			padding: 20px;
-			line-height: 1.5;
-		}
-		.container { max-width: 960px; margin: 0 auto; }
-		h1 { font-size: 1.4em; margin: 0 0 16px 0; color: #24292f; }
-		a { color: #0969da; text-decoration: none; }
-		a:hover { text-decoration: underline; }
-		form {
-			display: flex;
-			gap: 8px;
-			align-items: center;
-			flex-wrap: wrap;
-			margin-bottom: 16px;
-		}
-		input[type="text"] {
-			flex: 1;
-			min-width: 200px;
-			padding: 8px 12px;
-			background: #fff;
-			border: 1px solid #d0d7de;
-			border-radius: 6px;
-			color: #24292f;
-			font-size: 14px;
-		}
-		input[type="text"]:focus { outline: none; border-color: #0969da; box-shadow: 0 0 0 3px rgba(9,105,218,0.15); }
-		input[type="submit"] {
-			padding: 8px 16px;
-			background: #2da44e;
-			border: 1px solid #1b7f37;
-			border-radius: 6px;
-			color: #fff;
-			cursor: pointer;
-			font-size: 14px;
-			font-weight: 500;
-		}
-		input[type="submit"]:hover { background: #2c974b; }
-		select {
-			padding: 8px;
-			background: #fff;
-			border: 1px solid #d0d7de;
-			border-radius: 6px;
-			color: #24292f;
-			font-size: 14px;
-		}
-		.stats { color: #656d76; font-size: 13px; }
-		.results-layout { display: flex; gap: 24px; }
-		.results-main { flex: 4; min-width: 0; }
-		.results-sidebar { flex: 1; min-width: 150px; }
-		.result-item {
-			padding: 12px 0;
-			border-bottom: 1px solid #d8dee4;
-		}
-		.result-item h4 { margin: 0 0 4px 0; font-size: 14px; font-weight: normal; }
-		.result-item h4 a { color: #0969da; }
-		.result-item pre {
-			margin: 8px 0 4px 0;
-			padding: 10px;
-			background: #f6f8fa;
-			border: 1px solid #d0d7de;
-			border-radius: 6px;
-			font-family: "SF Mono", "Cascadia Code", "Fira Code", "Consolas", monospace;
-			font-size: 13px;
-			color: #24292f;
-			white-space: pre-wrap;
-			word-wrap: break-word;
-			overflow-x: auto;
-		}
-		.result-item strong {
-			background: #fff8c5;
-			border-bottom: 2px solid #d4a72c;
-			padding: 1px 2px;
-			border-radius: 2px;
-		}
-		.jump-link { font-size: 12px; color: #656d76; }
-		.jump-link a { color: #656d76; }
-		.jump-link a:hover { color: #0969da; }
-		.sidebar-heading {
-			font-size: 13px;
-			text-transform: uppercase;
-			letter-spacing: 0.5px;
-			color: #656d76;
-			margin: 0 0 8px 0;
-			padding-bottom: 6px;
-			border-bottom: 1px solid #d8dee4;
-		}
-		.facet-list { list-style: none; padding: 0; margin: 0; }
-		.facet-list li {
-			padding: 3px 0;
-			font-size: 13px;
-		}
-		.facet-list a { color: #24292f; }
-		.facet-list a:hover { color: #0969da; }
-		.facet-count { color: #656d76; font-size: 12px; }
-		.pages { padding: 16px 0; }
-		.pages a {
-			display: inline-block;
-			padding: 4px 10px;
-			margin-right: 4px;
-			background: #f6f8fa;
-			border: 1px solid #d0d7de;
-			border-radius: 6px;
-			font-size: 13px;
-			color: #24292f;
-		}
-		.pages a:hover { background: #eaeef2; }
-	</style>
-</head>
-<body>
-	<div class="container">
-		<form method="get" action="/">
-			<input type="text" name="q" value="{{ .SearchTerm }}" autofocus="autofocus" onfocus="this.select()" placeholder="Search..." />
-			<input type="submit" value="Search" />
-			<select name="ss" id="ss" onchange="this.form.submit()">
-				<option value="100" {{ if eq .SnippetSize 100 }}selected{{ end }}>100</option>
-				<option value="200" {{ if eq .SnippetSize 200 }}selected{{ end }}>200</option>
-				<option value="300" {{ if eq .SnippetSize 300 }}selected{{ end }}>300</option>
-				<option value="400" {{ if eq .SnippetSize 400 }}selected{{ end }}>400</option>
-				<option value="500" {{ if eq .SnippetSize 500 }}selected{{ end }}>500</option>
-				<option value="600" {{ if eq .SnippetSize 600 }}selected{{ end }}>600</option>
-				<option value="700" {{ if eq .SnippetSize 700 }}selected{{ end }}>700</option>
-				<option value="800" {{ if eq .SnippetSize 800 }}selected{{ end }}>800</option>
-				<option value="900" {{ if eq .SnippetSize 900 }}selected{{ end }}>900</option>
-				<option value="1000" {{ if eq .SnippetSize 1000 }}selected{{ end }}>1000</option>
-			</select>
-			<span class="stats">[{{ .ResultsCount }} results from {{ .ProcessedFileCount }} files in {{ .RuntimeMilliseconds }} ms]</span>
-		</form>
-
-		<div class="results-layout">
-			{{if .Results -}}
-			<div class="results-main">
-				{{- range .Results }}
-				<div class="result-item">
-					<h4><a href="/file/{{ .Location }}?sp={{ .StartPos }}&ep={{ .EndPos }}">{{ .Title }}</a>{{ if .Language }} <span style="color:#656d76;font-size:12px">({{ .Language }})</span>{{ end }}</h4>
-					{{ if .Lines }}<div class="stats">{{ .Language }} | Lines: {{ .Lines }} | Code: {{ .Code }} | Comment: {{ .Comment }} | Blank: {{ .Blank }} | Complexity: {{ .Complexity }}</div>{{ end }}
-					{{ if .IsLineMode }}<pre>{{ range .LineResults }}<span style="color:#808080;user-select:none">{{ printf "%4d " .LineNumber }}</span>{{ .Content }}
-{{ end }}</pre>{{ else }}{{- range .Content }}
-					<pre>{{ . }}</pre>
-					{{- end }}{{ end }}
-					<span class="jump-link">[<a href="/file/{{ .Location }}?sp={{ .StartPos }}&ep={{ .EndPos }}#{{ .StartPos }}">jump to match</a>]</span>
-				</div>
-				{{- end }}
-
-				<div class="pages">
-				{{- range .Pages }}
-					<a href="/?q={{ .SearchTerm }}&ss={{ .SnippetSize }}&p={{ .Value }}&ext={{ .Ext }}">{{ .Name }}</a>
-				{{- end }}
-				</div>
-			</div>
-			{{- end}}
-			{{if .ExtensionFacet }}
-			<div class="results-sidebar">
-				<div class="sidebar-heading">Extensions</div>
-				<ul class="facet-list">
-				{{- range .ExtensionFacet }}
-					<li><a href="/?q={{ .SearchTerm }}&ss={{ .SnippetSize }}&ext={{ .Title }}">{{ .Title }}</a> <span class="facet-count">({{ .Count }})</span></li>
-				{{- end }}
-				</ul>
-			</div>
-			{{- end }}
-		</div>
-	</div>
-</body>
-</html>
+{{ define "searchStyles" }}<style>
+*, *::before, *::after { box-sizing: border-box; }
+.cs-search-body {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+	background: #fff;
+	color: #24292f;
+	margin: 0;
+	padding: 20px;
+	line-height: 1.5;
+	overflow-y: scroll;
+	min-height: 100vh;
+}
+.cs-container { max-width: 960px; margin: 0 auto; }
+.cs-search-form { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 16px; }
+.cs-search-input {
+	padding: 8px 12px;
+	background: #fff;
+	border: 1px solid #d0d7de;
+	border-radius: 6px;
+	color: #24292f;
+	font-size: 14px;
+	min-width: 0;
+	flex: 1 1 auto;
+}
+.cs-search-input:focus { outline: none; border-color: #0969da; box-shadow: 0 0 0 3px rgba(9,105,218,0.15); }
+.cs-search-submit {
+	padding: 8px 16px;
+	background: #2da44e;
+	border: 1px solid #1b7f37;
+	border-radius: 6px;
+	color: #fff;
+	cursor: pointer;
+	font-size: 14px;
+	font-weight: 500;
+	flex: 0 0 auto;
+}
+.cs-search-submit:hover { background: #2c974b; }
+.cs-search-select {
+	padding: 8px;
+	background: #fff;
+	border: 1px solid #d0d7de;
+	border-radius: 6px;
+	color: #24292f;
+	font-size: 14px;
+	flex: 0 0 auto;
+}
+.cs-stats {
+	color: #656d76;
+	font-size: 13px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	font-variant-numeric: tabular-nums;
+	flex: 0 0 24ch;
+	min-width: 24ch;
+}
+a { color: #0969da; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.cs-results-layout { display: flex; gap: 24px; }
+.cs-results-main { flex: 4; min-width: 0; }
+.cs-results-sidebar { flex: 0 0 14rem; min-width: 14rem; }
+.cs-result-item {
+	padding: 12px 0;
+	border-bottom: 1px solid #d8dee4;
+}
+.cs-result-item h4 { margin: 0 0 4px 0; font-size: 14px; font-weight: normal; }
+.cs-result-item h4 a { color: #0969da; }
+.cs-result-item pre,
+.cs-result-linepre,
+.cs-snippet {
+	margin: 8px 0 4px 0;
+	padding: 10px;
+	background: #f6f8fa;
+	border: 1px solid #d0d7de;
+	border-radius: 6px;
+	font-family: "SF Mono", "Cascadia Code", "Fira Code", "Consolas", monospace;
+	font-size: 13px;
+	color: #24292f;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	overflow-x: auto;
+}
+.cs-result-item pre strong { background: #fff8c5; border-bottom: 2px solid #d4a72c; padding: 1px 2px; border-radius: 2px; }
+.cs-result-language { color: #656d76; font-size: 12px; }
+.cs-result-meta { color: #656d76; margin: 4px 0; }
+.cs-jump-link { font-size: 12px; color: #656d76; }
+.cs-jump-link a { color: #656d76; }
+.cs-jump-link a:hover { color: #0969da; }
+.cs-sidebar-heading {
+	font-size: 13px;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: #656d76;
+	margin: 0 0 8px 0;
+	padding-bottom: 6px;
+	border-bottom: 1px solid #d8dee4;
+}
+.cs-facet-list { list-style: none; padding: 0; margin: 0; }
+.cs-facet-list li {
+	padding: 3px 0;
+	font-size: 13px;
+}
+.cs-facet-list a { color: #24292f; }
+.cs-facet-list a:hover { color: #0969da; }
+.cs-facet-count { color: #656d76; font-size: 12px; }
+.cs-pages { padding: 16px 0; }
+.cs-pages a {
+	display: inline-block;
+	padding: 4px 10px;
+	margin-right: 4px;
+	background: #f6f8fa;
+	border: 1px solid #d0d7de;
+	border-radius: 6px;
+	font-size: 13px;
+	color: #24292f;
+}
+.cs-pages a:hover { background: #eaeef2; }
+.cs-result-lineno { color: #808080; user-select: none; }
+</style>{{ end }}

--- a/templates.go
+++ b/templates.go
@@ -9,7 +9,7 @@ import (
 	"os"
 )
 
-//go:embed asset/templates/bare/*.html asset/templates/dark/*.html asset/templates/light/*.html
+//go:embed asset/templates/base/*.html asset/templates/bare/*.html asset/templates/dark/*.html asset/templates/light/*.html
 var templateFS embed.FS
 
 var validStyles = []string{"dark", "light", "bare"}
@@ -29,12 +29,24 @@ func resolveSearchTemplate(cfg *Config) (*template.Template, error) {
 		return nil, fmt.Errorf("unknown template style %q (valid: dark, light, bare)", cfg.TemplateStyle)
 	}
 
+	basePath := "asset/templates/base/search.html"
+	baseData, err := templateFS.ReadFile(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading embedded base search template: %w", err)
+	}
+
 	path := fmt.Sprintf("asset/templates/%s/search.html", cfg.TemplateStyle)
 	data, err := templateFS.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading embedded search template for style %q: %w", cfg.TemplateStyle, err)
 	}
-	return template.New("search").Parse(string(data))
+
+	tmpl, err := template.New("search").Parse(string(baseData))
+	if err != nil {
+		return nil, fmt.Errorf("parsing base search template: %w", err)
+	}
+
+	return tmpl.Parse(string(data))
 }
 
 // resolveDisplayTemplate returns the parsed display template. Custom file override


### PR DESCRIPTION
Add real-time HTTP search while typing with debounced requests and cancellation.
Refactor search templates to a shared base template with style partials per theme (dark, light, bare).
Improve HTTP startup URL logging so it prints the exact full address. (and clickable now for faster access)
Stabilize layout sizing to reduce search/results jitter while typing.
Fix template stylesheet parsing issues by moving <style> tags into style partials.

Disclosure: Template refactor automated using AI

I explicitly licence my contribution under MIT