### PR TITLE
Fixes --find-root for git worktrees

### DIFF
--- a/search.go
+++ b/search.go
@@ -72,7 +72,7 @@ func DoSearch(ctx context.Context, cfg *Config, query string, cache *SearchCache
 		dir = cfg.Directory
 	}
 	if cfg.FindRoot {
-		dir = gocodewalker.FindRepositoryRoot(dir)
+		dir = findRepositoryRoot(dir)
 	}
 
 	// Resolve to absolute path once so downstream filepath.Abs() calls
@@ -397,4 +397,43 @@ func readFileContent(location string, maxBytes int64) ([]byte, error) {
 		return nil, err
 	}
 	return buf[:n], nil
+}
+
+// findRepositoryRoot walks startDir upward looking for a .git or .hg entry,
+// returning the first matching ancestor (inclusive of startDir) or startDir
+// if none is found. Unlike gocodewalker.FindRepositoryRoot, this recognizes
+// git worktrees, where .git is a regular file (containing "gitdir: …")
+// rather than a directory — so a nested worktree resolves to its own root
+// instead of the enclosing main repo.
+func findRepositoryRoot(startDir string) string {
+	abs, err := filepath.Abs(startDir)
+	if err != nil {
+		return startDir
+	}
+	dir := abs
+	for {
+		if hasRepoMarker(dir) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return startDir
+		}
+		dir = parent
+	}
+}
+
+// hasRepoMarker reports whether dir contains a .git or .hg entry.
+// .git is accepted as either a directory (normal repo) or a regular file
+// (git worktree, submodule).
+func hasRepoMarker(dir string) bool {
+	if stat, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		if stat.IsDir() || stat.Mode().IsRegular() {
+			return true
+		}
+	}
+	if stat, err := os.Stat(filepath.Join(dir, ".hg")); err == nil && stat.IsDir() {
+		return true
+	}
+	return false
 }

--- a/search_root_test.go
+++ b/search_root_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindRepositoryRoot(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Parent repo with a real .git directory.
+	parent := filepath.Join(tmp, "parent")
+	if err := os.MkdirAll(filepath.Join(parent, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nested worktree at parent/.agent-shell/wt with .git as a regular file
+	// (as `git worktree add` produces).
+	worktree := filepath.Join(parent, ".agent-shell", "wt")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitFile := filepath.Join(worktree, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: "+parent+"/.git/worktrees/wt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Subdirectory inside the worktree, so we exercise the upward walk.
+	worktreeSub := filepath.Join(worktree, "sub", "dir")
+	if err := os.MkdirAll(worktreeSub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plain directory with no repo marker anywhere up the tree (under tmp).
+	orphan := filepath.Join(tmp, "orphan")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		start string
+		want  string
+	}{
+		{"parent repo root", parent, parent},
+		{"worktree root", worktree, worktree},
+		{"nested dir inside worktree", worktreeSub, worktree},
+		{"no marker falls back to start", orphan, orphan},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findRepositoryRoot(tt.start)
+			// Resolve symlinks so /var vs /private/var on macOS doesn't trip the comparison.
+			gotR, _ := filepath.EvalSymlinks(got)
+			wantR, _ := filepath.EvalSymlinks(tt.want)
+			if gotR != wantR {
+				t.Errorf("findRepositoryRoot(%q) = %q, want %q", tt.start, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes `--find-root` for git worktrees #52

Unlike `gocodewalker.FindRepositoryRoot`, the fix recognizes git worktrees, where `.git` is a regular file (containing "gitdir: …") rather than a directory — so a nested worktree resolves to its own root instead of the enclosing repo.