### PR TITLE
Avoid false-positive declarations for value-binding

### DIFF
--- a/pkg/ranker/declarations.go
+++ b/pkg/ranker/declarations.go
@@ -9,6 +9,15 @@ import (
 // DeclarationPattern represents a line-start pattern that indicates a declaration.
 type DeclarationPattern struct {
 	Prefix []byte // bytes that the trimmed line must start with
+
+	// NameBindsAfterPrefix marks patterns where the declared identifier appears
+	// immediately after Prefix (e.g. `const NAME = ...`). For these,
+	// ClassifyMatchLocations only treats a match as a declaration when the match
+	// begins at that identifier position, so a usage on the right-hand side
+	// (`const x = someFn()`) is classified as a usage rather than a declaration.
+	// Left false for patterns whose declared name is not directly after the
+	// keyword (e.g. Go `func (r *T) Method()`), which keep line-level behaviour.
+	NameBindsAfterPrefix bool
 }
 
 // languageDeclarationPatterns maps scc language names to their declaration patterns.
@@ -18,9 +27,9 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 		{Prefix: []byte("func ")},
 		{Prefix: []byte("func(")},
 		{Prefix: []byte("type ")},
-		{Prefix: []byte("var ")},
+		{Prefix: []byte("var "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("var(")},
-		{Prefix: []byte("const ")},
+		{Prefix: []byte("const "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("const(")},
 	},
 	"Python": {
@@ -32,31 +41,31 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 		{Prefix: []byte("function ")},
 		{Prefix: []byte("function(")},
 		{Prefix: []byte("class ")},
-		{Prefix: []byte("const ")},
-		{Prefix: []byte("let ")},
-		{Prefix: []byte("var ")},
+		{Prefix: []byte("const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("let "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("var "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("export function ")},
 		{Prefix: []byte("export default function")},
 		{Prefix: []byte("export class ")},
-		{Prefix: []byte("export const ")},
-		{Prefix: []byte("export let ")},
+		{Prefix: []byte("export const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("export let "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("export default class")},
 	},
 	"TypeScript": {
 		{Prefix: []byte("function ")},
 		{Prefix: []byte("function(")},
 		{Prefix: []byte("class ")},
-		{Prefix: []byte("const ")},
-		{Prefix: []byte("let ")},
-		{Prefix: []byte("var ")},
+		{Prefix: []byte("const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("let "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("var "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("interface ")},
 		{Prefix: []byte("type ")},
 		{Prefix: []byte("enum ")},
 		{Prefix: []byte("export function ")},
 		{Prefix: []byte("export default function")},
 		{Prefix: []byte("export class ")},
-		{Prefix: []byte("export const ")},
-		{Prefix: []byte("export let ")},
+		{Prefix: []byte("export const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("export let "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("export default class")},
 		{Prefix: []byte("export interface ")},
 		{Prefix: []byte("export type ")},
@@ -66,17 +75,17 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 		{Prefix: []byte("function ")},
 		{Prefix: []byte("function(")},
 		{Prefix: []byte("class ")},
-		{Prefix: []byte("const ")},
-		{Prefix: []byte("let ")},
-		{Prefix: []byte("var ")},
+		{Prefix: []byte("const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("let "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("var "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("interface ")},
 		{Prefix: []byte("type ")},
 		{Prefix: []byte("enum ")},
 		{Prefix: []byte("export function ")},
 		{Prefix: []byte("export default function")},
 		{Prefix: []byte("export class ")},
-		{Prefix: []byte("export const ")},
-		{Prefix: []byte("export let ")},
+		{Prefix: []byte("export const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("export let "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("export default class")},
 		{Prefix: []byte("export interface ")},
 		{Prefix: []byte("export type ")},
@@ -95,10 +104,10 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 		{Prefix: []byte("impl ")},
 		{Prefix: []byte("type ")},
 		{Prefix: []byte("pub type ")},
-		{Prefix: []byte("const ")},
-		{Prefix: []byte("pub const ")},
-		{Prefix: []byte("static ")},
-		{Prefix: []byte("pub static ")},
+		{Prefix: []byte("const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("pub const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("static "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("pub static "), NameBindsAfterPrefix: true},
 	},
 	"Java": {
 		{Prefix: []byte("public class ")},
@@ -166,8 +175,8 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 		{Prefix: []byte("interface ")},
 		{Prefix: []byte("enum class ")},
 		{Prefix: []byte("typealias ")},
-		{Prefix: []byte("val ")},
-		{Prefix: []byte("var ")},
+		{Prefix: []byte("val "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("var "), NameBindsAfterPrefix: true},
 	},
 	"Swift": {
 		{Prefix: []byte("func ")},
@@ -176,8 +185,8 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 		{Prefix: []byte("enum ")},
 		{Prefix: []byte("protocol ")},
 		{Prefix: []byte("typealias ")},
-		{Prefix: []byte("let ")},
-		{Prefix: []byte("var ")},
+		{Prefix: []byte("let "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("var "), NameBindsAfterPrefix: true},
 	},
 	"Shell": {
 		{Prefix: []byte("function ")},
@@ -189,8 +198,8 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 	},
 	"Scala": {
 		{Prefix: []byte("def ")},
-		{Prefix: []byte("val ")},
-		{Prefix: []byte("var ")},
+		{Prefix: []byte("val "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("var "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("class ")},
 		{Prefix: []byte("trait ")},
 		{Prefix: []byte("object ")},
@@ -227,10 +236,10 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 	"Zig": {
 		{Prefix: []byte("fn ")},
 		{Prefix: []byte("pub fn ")},
-		{Prefix: []byte("const ")},
-		{Prefix: []byte("pub const ")},
-		{Prefix: []byte("var ")},
-		{Prefix: []byte("pub var ")},
+		{Prefix: []byte("const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("pub const "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("var "), NameBindsAfterPrefix: true},
+		{Prefix: []byte("pub var "), NameBindsAfterPrefix: true},
 	},
 	"Dart": {
 		{Prefix: []byte("class ")},
@@ -275,10 +284,10 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 		{Prefix: []byte("trait ")},
 	},
 	"OCaml": {
-		{Prefix: []byte("let ")},
+		{Prefix: []byte("let "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("type ")},
 		{Prefix: []byte("module ")},
-		{Prefix: []byte("val ")},
+		{Prefix: []byte("val "), NameBindsAfterPrefix: true},
 		{Prefix: []byte("external ")},
 	},
 	"MATLAB": {
@@ -313,7 +322,7 @@ var languageDeclarationPatterns = map[string][]DeclarationPattern{
 		{Prefix: []byte("pub struct ")},
 		{Prefix: []byte("enum ")},
 		{Prefix: []byte("type ")},
-		{Prefix: []byte("const ")},
+		{Prefix: []byte("const "), NameBindsAfterPrefix: true},
 	},
 }
 
@@ -330,6 +339,39 @@ func IsDeclarationLine(trimmedLine []byte, language string) bool {
 		if bytes.HasPrefix(trimmedLine, pat.Prefix) {
 			return true
 		}
+	}
+	return false
+}
+
+// isDeclarationMatch reports whether a match is a declaration of the matched
+// token, given the trimmed line it sits on and matchCol — the match's byte
+// offset relative to the start of the trimmed line.
+//
+// It refines IsDeclarationLine: for value-binding patterns (NameBindsAfterPrefix),
+// the match counts as a declaration only when it begins at the bound identifier
+// (immediately after the keyword), so `const x = someFn()` classifies the `x`
+// match as a declaration and the `someFn` match as a usage. All other patterns
+// keep line-level behaviour.
+func isDeclarationMatch(trimmedLine []byte, matchCol int, language string) bool {
+	patterns, ok := languageDeclarationPatterns[language]
+	if !ok {
+		return false
+	}
+
+	for _, pat := range patterns {
+		if !bytes.HasPrefix(trimmedLine, pat.Prefix) {
+			continue
+		}
+		if pat.NameBindsAfterPrefix {
+			// The bound identifier is the first token after the keyword. Skip any
+			// extra spacing between keyword and name so `const   x` still matches.
+			nameStart := len(pat.Prefix)
+			for nameStart < len(trimmedLine) && (trimmedLine[nameStart] == ' ' || trimmedLine[nameStart] == '\t') {
+				nameStart++
+			}
+			return matchCol == nameStart
+		}
+		return true
 	}
 	return false
 }
@@ -397,7 +439,13 @@ func ClassifyMatchLocations(
 			line := content[lineStart:lineEnd]
 			trimmedLine := bytes.TrimLeft(line, " \t")
 
-			if IsDeclarationLine(trimmedLine, language) {
+			// matchCol is the match offset relative to the start of the trimmed
+			// line, so value-binding patterns can require the match to sit at the
+			// bound identifier rather than anywhere on the line.
+			leadingWS := len(line) - len(trimmedLine)
+			matchCol := startByte - lineStart - leadingWS
+
+			if isDeclarationMatch(trimmedLine, matchCol, language) {
 				declarations[term] = append(declarations[term], loc)
 			} else {
 				usages[term] = append(usages[term], loc)

--- a/pkg/ranker/declarations_test.go
+++ b/pkg/ranker/declarations_test.go
@@ -3,6 +3,7 @@
 package ranker
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -893,6 +894,105 @@ func TestFindLine_SingleLine(t *testing.T) {
 	got := findLine(lineStarts, 5)
 	if got != 0 {
 		t.Errorf("findLine([0], 5) = %d, want 0", got)
+	}
+}
+
+// classifyTerm is a helper that classifies the single occurrence of term in
+// content for the given language, returning whether it landed in declarations.
+func classifyTerm(t *testing.T, content, term, language string) (isDecl, isUsage bool) {
+	t.Helper()
+	idx := bytes.Index([]byte(content), []byte(term))
+	if idx < 0 {
+		t.Fatalf("term %q not found in content", term)
+	}
+	locs := map[string][][]int{term: {{idx, idx + len(term)}}}
+	decl, usage := ClassifyMatchLocations([]byte(content), locs, language)
+	return len(decl[term]) > 0, len(usage[term]) > 0
+}
+
+func TestClassifyMatchLocations_TypeScriptBindingRHS(t *testing.T) {
+	// Bug 2: a function call on the RHS of a const/let/var binding must be a
+	// usage, not a declaration, even though the line starts with a binding keyword.
+	cases := []struct {
+		name     string
+		content  string
+		term     string
+		wantDecl bool
+	}{
+		{"const RHS call is a usage", "const context = await createCommandValidationContext();\n", "createCommandValidationContext", false},
+		{"const bound name is a declaration", "const context = await createCommandValidationContext();\n", "context", true},
+		{"let RHS call is a usage", "let result = computeThing();\n", "computeThing", false},
+		{"var RHS call is a usage", "var handler = makeHandler();\n", "makeHandler", false},
+		{"export const RHS call is a usage", "export const client = createClient();\n", "createClient", false},
+		{"export const bound name is a declaration", "export const client = createClient();\n", "client", true},
+		{"function declaration still detected", "export function fetchData(): void {\n", "fetchData", true},
+		{"extra spaces before bound name", "const    context = createCommandValidationContext();\n", "context", true},
+		{"extra spaces, RHS call still a usage", "const    context = createCommandValidationContext();\n", "createCommandValidationContext", false},
+		{"indented binding, RHS call still a usage", "        const result = computeResult();\n", "computeResult", false},
+		{"call inside indexed const line is a usage", "    const staleResults = await Promise.all(commandsWithHotkeys.map((entry) => isCommandStale(entry.id)));\n", "isCommandStale", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isDecl, isUsage := classifyTerm(t, tc.content, tc.term, "TypeScript")
+			if isDecl != tc.wantDecl {
+				t.Errorf("declaration=%v, want %v (usage=%v)", isDecl, tc.wantDecl, isUsage)
+			}
+			if isDecl == isUsage {
+				t.Errorf("match should be exactly one of declaration/usage, got decl=%v usage=%v", isDecl, isUsage)
+			}
+		})
+	}
+}
+
+func TestClassifyMatchLocations_BindingKeywordsAcrossLanguages(t *testing.T) {
+	// For value-binding keywords across languages, a call on the right-hand side
+	// is a usage, the bound name is the declaration, and a real function/type
+	// declaration of the same name stays a declaration.
+	cases := []struct {
+		name     string
+		language string
+		content  string
+		term     string
+		wantDecl bool
+	}{
+		{"Go var RHS call", "Go", "var handler = makeHandler()\n", "makeHandler", false},
+		{"Go var bound name", "Go", "var handler = makeHandler()\n", "handler", true},
+		{"Go const RHS call", "Go", "const limit = computeLimit()\n", "computeLimit", false},
+		{"Go func decl unaffected", "Go", "func computeLimit() int {\n", "computeLimit", true},
+
+		{"Rust const RHS call", "Rust", "const MAX: i32 = computeMax();\n", "computeMax", false},
+		{"Rust static RHS call", "Rust", "static REG: Reg = buildReg();\n", "buildReg", false},
+		{"Rust pub const RHS call", "Rust", "pub const MAX: i32 = computeMax();\n", "computeMax", false},
+		{"Rust fn decl unaffected", "Rust", "fn computeMax() -> i32 {\n", "computeMax", true},
+
+		{"Swift let RHS call", "Swift", "let value = makeThing()\n", "makeThing", false},
+		{"Kotlin val RHS call", "Kotlin", "val client = createClient()\n", "createClient", false},
+		{"Scala val RHS call", "Scala", "val result = compute()\n", "compute", false},
+		{"Zig const RHS call", "Zig", "const handle = openHandle();\n", "openHandle", false},
+		{"OCaml let RHS call", "OCaml", "let x = computeValue ()\n", "computeValue", false},
+		{"V const RHS call", "V", "const answer = makeAnswer()\n", "makeAnswer", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isDecl, isUsage := classifyTerm(t, tc.content, tc.term, tc.language)
+			if isDecl != tc.wantDecl {
+				t.Errorf("declaration=%v, want %v (usage=%v)", isDecl, tc.wantDecl, isUsage)
+			}
+			if isDecl == isUsage {
+				t.Errorf("match should be exactly one of declaration/usage, got decl=%v usage=%v", isDecl, isUsage)
+			}
+		})
+	}
+}
+
+func TestClassifyMatchLocations_GoMethodUnaffected(t *testing.T) {
+	// Go `func ` is not a binding pattern, so a receiver-method name that is not
+	// directly after the keyword must still be classified as a declaration.
+	isDecl, _ := classifyTerm(t, "func (r *Receiver) Method() {\n}\n", "Method", "Go")
+	if !isDecl {
+		t.Error("Go receiver method name should remain a declaration (line-level)")
 	}
 }
 


### PR DESCRIPTION
**Problem**
`only-declarations` classified each match purely by whether its line starts with a declaration keyword. A function call on the right-hand side of a binding — e.g. `const ctx = await makeContext()` — sits on a line starting with `const`, so the `makeContext` match was wrongly tagged a declaration. Net effect: real definitions were crowded out by/confused with call sites that happen to sit on const/let/var lines.

**Fix**
Add a `NameBindsAfterPrefix` flag to declaration patterns. For value-binding keywords, `ClassifyMatchLocations` now only treats a match as a declaration when it begins at the bound identifier - the first token after the keyword, tolerating extra spaces. So `ctx` is the declaration and `makeContext` is a usage. Non-binding keywords (func/fn/def/class/type/…) keep line-level behavior, so cases where the declared name isn't adjacent to the keyword — e.g. `Go func (r *T) Method()` — are unaffected.

**Flagged value-binding keywords:** 
- JS/TS/TSX const/let/var (+export)
- Go var/const
- Rust const/static (+pub)
- Kotlin val/var
- Swift let/var
- Scala val/var
- Zig const/var (+pub)
- OCaml let/val
- V const.

**Scope & tests**
Change confined to `ClassifyMatchLocations`. `IsDeclarationLine` (used by ranking via `ranker_min.go`) is untouched, so ranking is unaffected. Added cross-language classification tests plus a Go-method regression guard; existing tests unchanged.

**Known limitations**
Not handled:

- Destructuring / multi-declarator names e.g.`const { x } = …`, `const a = 1, b = 2`
- Literal tab as the keyword/name separator 
