### PR TITLE
Add `path` and `file` parameters to search requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,11 @@ The MCP server exposes two tools:
 | `gravity` | string | no | Complexity gravity intent: `brain`, `logic`, `default`, `low`, `off`                             |
 | `profile` | string | no | Ranking profile: `balanced` (default), `precise`, `broad` - overrides gravity/noise/test-penalty |
 
+The `path`, `file`, `include_ext`, and `language` parameters apply to the whole query and are the robust way to
+scope a search — unlike in-query filters (`path:`, `file:`, `ext:`, `lang:`), which bind only to the adjacent term
+(`a OR b path:src` means `a OR (b AND path:src)`). Note there is no top-level `ext` parameter; use `include_ext`.
+Unknown parameters are rejected with an error rather than silently ignored.
+
 Results are returned as JSON with the same fields as `--format json`: filename, location, score, snippet content, match locations, language, and code statistics.
 
 **`get_file`** — Read the contents of a file within the project directory.

--- a/README.md
+++ b/README.md
@@ -496,6 +496,8 @@ The MCP server exposes two tools:
 | `case_sensitive` | boolean | no | Case sensitive search                                                                            |
 | `include_ext` | string | no | Comma-separated file extensions (e.g. `go,js,py`)                                                |
 | `language` | string | no | Comma-separated language types (e.g. `Go,Python`)                                                |
+| `path` | string | no | Restrict to files whose full path matches (substring or glob; comma-separated values are ORed). ANDed against the whole query |
+| `file` | string | no | Restrict to files whose filename matches (substring or glob; comma-separated values are ORed). ANDed against the whole query |
 | `gravity` | string | no | Complexity gravity intent: `brain`, `logic`, `default`, `low`, `off`                             |
 | `profile` | string | no | Ranking profile: `balanced` (default), `precise`, `broad` - overrides gravity/noise/test-penalty |
 

--- a/mcp.go
+++ b/mcp.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/boyter/cs/v3/pkg/common"
@@ -328,6 +329,37 @@ func mcpGetFileHandler(cfg *Config) server.ToolHandlerFunc {
 	}
 }
 
+// mcpSearchParams is the set of accepted parameters for the search tool, in a
+// stable order for error messages. Any argument not in this set is rejected so
+// that malformed calls (e.g. a non-existent "ext" or "path" top-level key) fail
+// loudly instead of being silently dropped and running an unfiltered search.
+var mcpSearchParams = []string{
+	"query", "max_results", "offset", "snippet_length", "case_sensitive",
+	"include_ext", "language", "path", "file", "gravity", "profile", "dedup",
+	"code_filter", "snippet_mode", "line_limit", "context", "context_before", "context_after",
+}
+
+var mcpSearchParamSet = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(mcpSearchParams))
+	for _, p := range mcpSearchParams {
+		m[p] = struct{}{}
+	}
+	return m
+}()
+
+// unknownSearchParams returns any argument keys that are not accepted params,
+// sorted for a stable error message.
+func unknownSearchParams(args map[string]any) []string {
+	var unknown []string
+	for k := range args {
+		if _, ok := mcpSearchParamSet[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
 // mcpSearchHandler returns an MCP tool handler that runs a code search.
 func mcpSearchHandler(cfg *Config, cache *SearchCache) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -337,6 +369,17 @@ func mcpSearchHandler(cfg *Config, cache *SearchCache) server.ToolHandlerFunc {
 		}
 		if strings.TrimSpace(query) == "" {
 			return mcp.NewToolResultError("query must not be empty"), nil
+		}
+
+		// Reject unknown parameters so malformed calls fail loudly instead of
+		// silently running an unfiltered search (e.g. a caller passing a
+		// non-existent top-level "ext" or "path" key and getting whole-repo results).
+		if unknown := unknownSearchParams(request.GetArguments()); len(unknown) > 0 {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"unknown parameter(s): %s. To filter by path, filename, extension, or language use the "+
+					"'path', 'file', 'include_ext', or 'language' parameters (there is no top-level 'ext' parameter), "+
+					"or in-query filters (path:, file:, ext:, lang:). Accepted parameters: %s.",
+				strings.Join(unknown, ", "), strings.Join(mcpSearchParams, ", "))), nil
 		}
 
 		// Copy config so we can override per-request without mutating the shared config

--- a/mcp.go
+++ b/mcp.go
@@ -74,6 +74,15 @@ func StartMCPServer(cfg *Config) {
 			"- ext:value — filter by extension: ext:go, ext=ts,tsx\n\n"+
 			"Filter operators: = != (e.g. lang!=python, file!=test)\n"+
 			"Negation: NOT file:test, file!=test, NOT path:vendor, path!=vendor\n\n"+
+			"IMPORTANT — filter precedence: an in-query filter binds to the ADJACENT term, not the whole query. "+
+			"So 'a OR b path:src' parses as 'a OR (b AND path:src)' and matches for 'a' leak in from ANY path. "+
+			"To scope the whole query, either group it — '(a OR b) path:src' — or use the top-level 'path'/'file' "+
+			"parameters, which are ANDed with the entire query regardless of OR grouping. Same rule applies to lang:/ext:.\n\n"+
+			"Top-level filter parameters (path, file, include_ext, language) are the ROBUST way to scope a search: "+
+			"they apply to the whole query, so they never hit the precedence trap above. Prefer them over in-query filters "+
+			"when you just want to restrict a search to a directory, filename, extension, or language. "+
+			"NOTE: there is no top-level 'ext' parameter — the extension parameter is named 'include_ext'. "+
+			"Unknown parameters are rejected with an error rather than silently ignored.\n\n"+
 			"Content type filter (code_filter parameter):\n"+
 			"- 'only-code': matches in code only, skipping comments and strings — e.g. find where a function is called, not just mentioned\n"+
 			"- 'only-strings': matches in string literals only — find SQL queries, error messages, config values, connection strings\n"+
@@ -96,6 +105,7 @@ func StartMCPServer(cfg *Config) {
 			"- For structural patterns use regex: '/type\\s+\\w+Error\\s+struct/' not 'type Error struct'. Keywords match anywhere in the file, not adjacently.\n"+
 			"- Common regex mistake: `magic.*number` without slashes is treated as the keyword 'magic.*number', not as regex. Always wrap in slashes: `/magic.*number/`.\n"+
 			"- NOT binds to the next term only, not the whole query. 'a OR b NOT path:vendor' means 'a OR (b AND NOT path:vendor)'. To exclude globally, use grouping: '(a OR b) NOT path:vendor'. Precedence: NOT (tightest) > AND > OR (loosest).\n"+
+			"- The same trap applies to POSITIVE filters: 'a OR b path:src' means 'a OR (b AND path:src)', so 'a' matches leak in from any path. Group the query — '(a OR b) path:src' — or use the top-level 'path'/'file'/'include_ext'/'language' parameters, which scope the whole query.\n"+
 			"- max_results defaults to 20. Set higher (e.g. 100) for broad discovery or exploring unfamiliar code.\n\n"+
 			"Workflow tips:\n"+
 			"- Searching for a specific term, identifier, or function name → use snippet_mode='grep' with context=5-10. This gives every occurrence with surrounding code in one call.\n"+
@@ -107,6 +117,8 @@ func StartMCPServer(cfg *Config) {
 				"grouping ('(auth OR login) AND handler'), quoted phrases ('\"exact match\"'), regex (/pattern/), fuzzy (term~1, term~2). "+
 				"In-query filters: file:name, path:dir, lang:go, ext:ts. Operators: = != (lang!=python, file!=test). "+
 				"Multi-value: lang=go,python, ext=ts,tsx. 'file:' matches filename only; 'path:' matches the full directory path. "+
+				"NOTE: in-query filters bind to the adjacent term — 'a OR b path:src' means 'a OR (b AND path:src)'. Group with parens "+
+				"or use the top-level 'path'/'file'/'include_ext'/'language' parameters to scope the whole query. "+
 				"Query limits: max 250 characters and 12 unique search terms."),
 			mcp.Required(),
 		),

--- a/mcp.go
+++ b/mcp.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/boyter/cs/v3/pkg/common"
 	"github.com/boyter/cs/v3/pkg/ranker"
+	"github.com/boyter/cs/v3/pkg/search"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -427,6 +428,58 @@ func composeSearchQuery(query, pathFilter, fileFilter string) string {
 	return "(" + query + ") " + strings.Join(groups, " ")
 }
 
+// andedKeywordsForHint returns the positive, bare keyword terms of a query when
+// the query is a pure conjunction of keywords (contains no OR). It returns nil
+// when the query already uses OR, or has fewer than two positive keyword terms —
+// i.e. when an "all terms ANDed" hint would not apply. Phrases, regex, fuzzy and
+// filter terms are ignored, and negated keywords (under NOT) are excluded.
+func andedKeywordsForHint(query string) []string {
+	lexer := search.NewLexer(strings.NewReader(query))
+	parser := search.NewParser(lexer)
+	ast, _ := parser.ParseQuery()
+	if ast == nil {
+		return nil
+	}
+
+	var keywords []string
+	hasOr := false
+	var walk func(n search.Node, negated bool)
+	walk = func(n search.Node, negated bool) {
+		switch t := n.(type) {
+		case *search.AndNode:
+			walk(t.Left, negated)
+			walk(t.Right, negated)
+		case *search.OrNode:
+			hasOr = true
+		case *search.NotNode:
+			walk(t.Expr, !negated)
+		case *search.KeywordNode:
+			if !negated {
+				keywords = append(keywords, t.Value)
+			}
+		}
+	}
+	walk(ast, false)
+
+	if hasOr || len(keywords) < 2 {
+		return nil
+	}
+	return keywords
+}
+
+// andHintMessage builds the empty-result explanation for a multi-term AND query,
+// nudging the caller toward fewer terms or an OR query.
+func andHintMessage(keywords []string) string {
+	quoted := make([]string, len(keywords))
+	for i, k := range keywords {
+		quoted[i] = "\"" + k + "\""
+	}
+	return fmt.Sprintf(
+		"0 results. Terms are ANDed, so this requires all %d of %s in a single file. "+
+			"Try fewer/more-specific terms, or OR them to match any: '%s'.",
+		len(keywords), strings.Join(quoted, ", "), strings.Join(keywords, " OR "))
+}
+
 // mcpSearchHandler returns an MCP tool handler that runs a code search.
 func mcpSearchHandler(cfg *Config, cache *SearchCache) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -463,6 +516,7 @@ func mcpSearchHandler(cfg *Config, cache *SearchCache) server.ToolHandlerFunc {
 				fileFilter = s
 			}
 		}
+		userQuery := query
 		query = composeSearchQuery(query, pathFilter, fileFilter)
 
 		// Copy config so we can override per-request without mutating the shared config
@@ -632,6 +686,14 @@ func mcpSearchHandler(cfg *Config, cache *SearchCache) server.ToolHandlerFunc {
 				"Showing results %d\u2013%d of %d. Pass offset=%d for the next page.",
 				startResult, endResult, totalMatches, nextOffset,
 			)
+		} else if totalMatches == 0 {
+			// Explain the most common cause of a surprising empty result: a
+			// multi-word query whose terms are all ANDed. Only fires for pure
+			// AND-of-keywords queries (no OR), analysed on the caller's original
+			// query rather than the path/file-composed one.
+			if kws := andedKeywordsForHint(userQuery); len(kws) > 0 {
+				response.Message = andHintMessage(kws)
+			}
 		}
 
 		jsonBytes, err := json.Marshal(response)

--- a/mcp.go
+++ b/mcp.go
@@ -83,7 +83,7 @@ func StartMCPServer(cfg *Config) {
 			"Combined examples:\n"+
 			"- 'jwt middleware lang:go NOT path:vendor' — find Go JWT middleware outside vendor\n"+
 			"- query='dense_rank' code_filter='only-strings' — find the actual SQL string, not code references\n"+
-			"- query='middleware' code_filter='only-code' path filter='NOT path:vendor' — find middleware implementations\n"+
+			"- query='middleware' code_filter='only-code' path='src' — find middleware implementations scoped to src via the top-level path param\n"+
 			"- query='authentication' code_filter='only-comments' — find where devs explain auth flow\n"+
 			"- query='ConnectDB' code_filter='only-declarations' language='Go' — find where ConnectDB is defined (func/type/var declaration)\n"+
 			"- query='ConnectDB' code_filter='only-usages' language='Go' — find all call sites of ConnectDB, excluding its definition\n\n"+
@@ -127,6 +127,19 @@ func StartMCPServer(cfg *Config) {
 		),
 		mcp.WithString("language",
 			mcp.Description("Comma-separated list of language types to search (e.g. \"Go,Python,JavaScript\"). Convenience parameter equivalent to in-query 'lang:Go,Python' filter."),
+		),
+		mcp.WithString("path",
+			mcp.Description("Restrict results to files whose full path matches. Substring match (e.g. \"src/handlers\"), or glob if it "+
+				"contains */?/[ (e.g. \"*/pkg/*\"). Comma-separated values are ORed (e.g. \"src,internal\" = under src OR internal). "+
+				"Applied as an AND against the ENTIRE query, so — unlike an in-query 'path:' filter — it is never subject to OR "+
+				"precedence and cannot be leaked past. This is the robust way to scope a search to a directory. "+
+				"Equivalent to wrapping your query: '(<query>) path:<value>'."),
+		),
+		mcp.WithString("file",
+			mcp.Description("Restrict results to files whose FILENAME matches (not the directory path — use 'path' for that). Substring match "+
+				"(e.g. \"handler\"), or glob if it contains */?/[ (e.g. \"*_test.go\"). Comma-separated values are ORed. "+
+				"Applied as an AND against the entire query, so it is never subject to OR precedence. Equivalent to "+
+				"wrapping your query: '(<query>) file:<value>'."),
 		),
 		mcp.WithString("gravity",
 			mcp.Description("Complexity gravity intent controlling how much cyclomatic complexity boosts ranking. "+
@@ -360,6 +373,48 @@ func unknownSearchParams(args map[string]any) []string {
 	return unknown
 }
 
+// buildFilterGroup turns a comma-separated top-level filter value into an
+// in-query clause for the given field ("path" or "file"). Multiple values are
+// ORed and wrapped in parens so the group evaluates as a single unit. Returns
+// "" when there is nothing to add.
+func buildFilterGroup(field, raw string) string {
+	var clauses []string
+	for _, v := range strings.Split(raw, ",") {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		clauses = append(clauses, field+":"+v)
+	}
+	switch len(clauses) {
+	case 0:
+		return ""
+	case 1:
+		return clauses[0]
+	default:
+		return "(" + strings.Join(clauses, " OR ") + ")"
+	}
+}
+
+// composeSearchQuery folds the top-level path/file filters into the query so
+// they AND against the WHOLE query, immune to OR precedence. The user query is
+// wrapped in parens and each filter group is appended (juxtaposition = AND).
+// The composed string flows through the normal parser and cache key, so it
+// behaves exactly as if the caller had written the filters in-query themselves.
+func composeSearchQuery(query, pathFilter, fileFilter string) string {
+	var groups []string
+	if g := buildFilterGroup("path", pathFilter); g != "" {
+		groups = append(groups, g)
+	}
+	if g := buildFilterGroup("file", fileFilter); g != "" {
+		groups = append(groups, g)
+	}
+	if len(groups) == 0 {
+		return query
+	}
+	return "(" + query + ") " + strings.Join(groups, " ")
+}
+
 // mcpSearchHandler returns an MCP tool handler that runs a code search.
 func mcpSearchHandler(cfg *Config, cache *SearchCache) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -381,6 +436,22 @@ func mcpSearchHandler(cfg *Config, cache *SearchCache) server.ToolHandlerFunc {
 					"or in-query filters (path:, file:, ext:, lang:). Accepted parameters: %s.",
 				strings.Join(unknown, ", "), strings.Join(mcpSearchParams, ", "))), nil
 		}
+
+		// Fold top-level path/file filters into the query so they AND against the
+		// whole query, immune to OR precedence.
+		pathFilter := ""
+		if v, ok := request.GetArguments()["path"]; ok {
+			if s, ok := v.(string); ok {
+				pathFilter = s
+			}
+		}
+		fileFilter := ""
+		if v, ok := request.GetArguments()["file"]; ok {
+			if s, ok := v.(string); ok {
+				fileFilter = s
+			}
+		}
+		query = composeSearchQuery(query, pathFilter, fileFilter)
 
 		// Copy config so we can override per-request without mutating the shared config
 		searchCfg := *cfg

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -391,6 +391,91 @@ func TestComposeSearchQuery(t *testing.T) {
 	}
 }
 
+func TestAndedKeywordsForHint(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{"multi keyword AND", "database init startup sequence", []string{"database", "init", "startup", "sequence"}},
+		{"single keyword", "database", nil},
+		{"has OR", "database OR init OR startup", nil},
+		{"grouped OR", "(database OR init) startup", nil},
+		{"phrase not counted", `"database init"`, nil},
+		{"regex not counted", `/func\s+init/`, nil},
+		{"negated excluded", "database NOT init", nil},
+		{"keywords plus filter still hints", "database init path:src", []string{"database", "init"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := andedKeywordsForHint(tc.query)
+			if len(got) != len(tc.want) {
+				t.Fatalf("andedKeywordsForHint(%q) = %v, want %v", tc.query, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("andedKeywordsForHint(%q) = %v, want %v", tc.query, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestMCPSearchHandlerEmptyResultAndHint(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Directory = t.TempDir() // empty dir → guaranteed zero matches
+	cache := NewSearchCache()
+	handler := mcpSearchHandler(&cfg, cache)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"query": "performStartupStep database init startup sequence",
+	}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content[0].(mcp.TextContent).Text)
+	}
+	var parsed mcpSearchResponse
+	if err := json.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed.TotalMatches != 0 {
+		t.Fatalf("expected 0 matches, got %d", parsed.TotalMatches)
+	}
+	if !strings.Contains(parsed.Message, "ANDed") {
+		t.Errorf("expected an AND-explanation hint, got: %q", parsed.Message)
+	}
+	if !strings.Contains(parsed.Message, "OR") {
+		t.Errorf("expected the hint to suggest OR, got: %q", parsed.Message)
+	}
+}
+
+func TestMCPSearchHandlerEmptyResultNoHintForSingleTerm(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Directory = t.TempDir()
+	cache := NewSearchCache()
+	handler := mcpSearchHandler(&cfg, cache)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"query": "loneterm",
+	}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed mcpSearchResponse
+	if err := json.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed.Message != "" {
+		t.Errorf("expected no hint for a single-term query, got: %q", parsed.Message)
+	}
+}
+
 func TestMCPGetFileHandlerMissingPath(t *testing.T) {
 	cfg := DefaultConfig()
 	handler := mcpGetFileHandler(&cfg)

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -274,6 +274,58 @@ func TestMCPSearchHandlerNoTruncation(t *testing.T) {
 	}
 }
 
+func TestMCPSearchHandlerRejectsUnknownParam(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Directory = t.TempDir()
+	cache := NewSearchCache()
+	handler := mcpSearchHandler(&cfg, cache)
+
+	// Reproduces the reported bug: caller passes non-existent top-level
+	// "path" and "ext" keys. These must be rejected, not silently dropped.
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"query": "classic migration backup bootstrap",
+		"path":  "projects/desktop-raycast/packages/node-backend/src",
+		"ext":   "ts",
+	}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for unknown parameter")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "ext") {
+		t.Errorf("expected error to name the unknown 'ext' parameter, got: %s", text)
+	}
+	if !strings.Contains(text, "include_ext") {
+		t.Errorf("expected error to point to 'include_ext', got: %s", text)
+	}
+}
+
+func TestMCPSearchHandlerAcceptsKnownParams(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Directory = t.TempDir()
+	cache := NewSearchCache()
+	handler := mcpSearchHandler(&cfg, cache)
+
+	// "path" is a valid top-level param — this must not be rejected.
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"query": "anything",
+		"path":  "src",
+		"file":  "*.go",
+	}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result for valid params: %v", result.Content[0].(mcp.TextContent).Text)
+	}
+}
+
 func TestMCPGetFileHandlerMissingPath(t *testing.T) {
 	cfg := DefaultConfig()
 	handler := mcpGetFileHandler(&cfg)

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -326,6 +326,71 @@ func TestMCPSearchHandlerAcceptsKnownParams(t *testing.T) {
 	}
 }
 
+func TestMCPSearchHandlerTopLevelPathScopesGlobally(t *testing.T) {
+	dir := t.TempDir()
+	// Two dirs. Only "wanted" should survive a path filter, even though the
+	// query uses OR (which would leak "other" matches via in-query precedence).
+	for _, sub := range []string{"wanted", "other"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+		content := "package main\n\nfunc f() {\n\t// alphatoken betatoken\n}\n"
+		if err := os.WriteFile(filepath.Join(dir, sub, "f.go"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := DefaultConfig()
+	cfg.Directory = dir
+	cache := NewSearchCache()
+	handler := mcpSearchHandler(&cfg, cache)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"query": "alphatoken OR betatoken",
+		"path":  "wanted",
+	}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content[0].(mcp.TextContent).Text)
+	}
+	var parsed mcpSearchResponse
+	if err := json.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed.TotalMatches != 1 {
+		t.Fatalf("expected exactly 1 match under 'wanted', got %d", parsed.TotalMatches)
+	}
+	if !strings.Contains(parsed.Results[0].Location, filepath.Join("wanted", "f.go")) {
+		t.Errorf("expected match in wanted/f.go, got %s", parsed.Results[0].Location)
+	}
+}
+
+func TestComposeSearchQuery(t *testing.T) {
+	cases := []struct {
+		name             string
+		query, path, fil string
+		want             string
+	}{
+		{"none", "foo OR bar", "", "", "foo OR bar"},
+		{"path", "foo OR bar", "src", "", "(foo OR bar) path:src"},
+		{"file", "foo", "", "*.go", "(foo) file:*.go"},
+		{"both", "foo", "src", "*.go", "(foo) path:src file:*.go"},
+		{"multi-path ORed", "foo", "src,internal", "", "(foo) (path:src OR path:internal)"},
+		{"trims and skips empties", "foo", " src , ", "", "(foo) path:src"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := composeSearchQuery(tc.query, tc.path, tc.fil); got != tc.want {
+				t.Errorf("composeSearchQuery(%q, %q, %q) = %q, want %q", tc.query, tc.path, tc.fil, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMCPGetFileHandlerMissingPath(t *testing.T) {
 	cfg := DefaultConfig()
 	handler := mcpGetFileHandler(&cfg)


### PR DESCRIPTION
Various improvements to improve `search` usage by agents:

**1. Unknown request params now fail loudly**
I've noticed that agents sometimes try and include unsupported params in the request e.g.  `path` and `ext`. Currently they are ignored, so the results return plausible garbage.

I've added an `mcpSearchParams` whitelist (single source of truth, also used to build the schema-agnostic set) and an `unknownSearchParams` guard at the top of `mcpSearchHandler`. So the caller gets an immediate, self-correcting error.

**2. Top-level `path` and `file` params**
Registered both and wired them through `composeSearchQuery,` which wraps the user query in parens and ANDs the filter groups: `(<query>) path:src file:*.go`. This is in addition to the existing in-query filters.

Key properties:
- Immune to the OR-precedence trap — because the whole query is parenthesized, alphatoken OR betatoken + path:wanted only returns wanted/, never leaks. (Directly tested.)
- Comma-separated values are ORed (src,internal → (path:src OR path:internal)), matching include_ext's multi-value convention.
- Reuses the existing, cache-correct in-query machinery — the composed string flows through the same parser and cache key, so behavior is identical to a hand-written filter. No new evaluation path, no cache-correctness risk.

**3. Documented the query precedence**
Added an explicit note that in-query filters bind to the adjacent term (mirroring the existing NOT note but for positive filters), called out that there is no top-level `ext` (it's `include_ext`) — the exact wrong inference the agent made — and pointed at the top-level params as the robust alternative. Also fixed a pre-existing bogus example (path filter='NOT path:vendor', not a real param).

**4. Return a message if multiple query keywords return zero results**
Agents seem to constantly trip up on the default AND logic for query keywords. So the caller gets an immediate, self-correcting error if the search returns zero results.