### PR TITLE
Add default-operator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,16 @@ the default `AND` is often too restrictive and returns zero results.
 cs --default-operator=or foo bar baz
 ```
 
+Even with `or`, metadata filters (`path:`, `ext:`, `file:`, `lang:`,
+`complexity:`, …) still constrain the whole query rather than being OR'd with
+individual terms. For example `foo bar path:pkg` is treated as
+`(foo OR bar) AND path:pkg`, so the filter applies no matter where it appears in
+the query. An explicit `foo OR path:pkg` is left as written.
+
+A filter inside parentheses is scoped to that group: `(foo path:pkg) bar` means
+`(foo AND path:pkg) OR bar`, so `path:pkg` constrains only `foo` while `bar`
+matches anywhere. A filter outside any group still applies to the whole query.
+
 ### Usage
 
 Command line usage of `cs` is designed to be as simple as possible.

--- a/README.md
+++ b/README.md
@@ -307,6 +307,21 @@ cs -d --template-style light
 cs -d --template-display ./asset/templates/display.tmpl --template-search ./asset/templates/search.tmpl
 ```
 
+### Default operator
+
+Adjacent terms with no explicit `AND`/`OR` between them are combined with the
+default operator, set by `--default-operator`:
+
+- `and` (default) requires all terms, so `foo bar` matches files containing both.
+- `or` matches any term, so `foo bar` matches files containing either.
+
+`or` is handy for tools and agents that issue broad multi-keyword queries, where
+the default `AND` is often too restrictive and returns zero results.
+
+```shell
+cs --default-operator=or foo bar baz
+```
+
 ### Usage
 
 Command line usage of `cs` is designed to be as simple as possible.
@@ -327,6 +342,7 @@ or in a TUI mode with no arguments. Can also run in HTTP mode with
 the -d or --http-server flag.
 
 Searches by default use AND boolean syntax for all terms
+ - use --default-operator=or (or a settings file) to combine terms with OR
  - exact match using quotes "find this"
  - fuzzy match within 1 or 2 distance fuzzy~1 fuzzy~2
  - negate using NOT such as pride NOT prejudice
@@ -367,6 +383,7 @@ Flags:
   -C, --context int                  lines of context before and after each match (grep mode)
       --cpu-profile string           write CPU profile to file (for use with go tool pprof or PGO)
       --dedup                        collapse byte-identical search matches, keeping the highest-scored representative
+      --default-operator string      how to combine adjacent terms with no explicit AND/OR [and, or]. 'or' is useful for broad multi-keyword searches (default "and")
       --dir string                   directory to search, if not set defaults to current working directory
       --exclude-dir strings          directories to exclude (default [.git,.hg,.svn])
   -x, --exclude-pattern strings      file and directory locations matching case sensitive patterns will be ignored [comma separated list: e.g. vendor,_test.go]

--- a/config.go
+++ b/config.go
@@ -3,11 +3,13 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/boyter/cs/v3/pkg/common"
 	"github.com/boyter/cs/v3/pkg/ranker"
+	"github.com/boyter/cs/v3/pkg/search"
 	"github.com/boyter/cs/v3/pkg/snippet"
 	"github.com/boyter/gocodewalker"
 )
@@ -36,6 +38,10 @@ type Config struct {
 	TestPenalty   float64
 	ResultLimit   int
 	LineLimit     int
+
+	// DefaultOperator combines adjacent terms with no explicit AND/OR between
+	// them: "and" (default) requires all terms, "or" matches any term.
+	DefaultOperator string
 
 	// File walker
 	Directory              string
@@ -109,6 +115,7 @@ func DefaultConfig() Config {
 		TestPenalty:            0.4,
 		ResultLimit:            -1,
 		LineLimit:              -1,
+		DefaultOperator:        "and",
 		PathDenylist:           []string{".git", ".hg", ".svn"},
 		MinifiedLineByteLength: 255,
 		MaxReadSizeBytes:       1_000_000,
@@ -204,6 +211,19 @@ func (c *Config) ResolveNoiseSensitivity() float64 {
 		return 100.0
 	default:
 		return 1.0
+	}
+}
+
+// ResolveDefaultOperator maps the DefaultOperator string to the search package
+// enum. It returns an error for unrecognised values.
+func (c *Config) ResolveDefaultOperator() (search.DefaultOperator, error) {
+	switch strings.ToLower(strings.TrimSpace(c.DefaultOperator)) {
+	case "and", "":
+		return search.DefaultAnd, nil
+	case "or":
+		return search.DefaultOr, nil
+	default:
+		return search.DefaultAnd, fmt.Errorf("unknown default-operator %q (valid: and, or)", c.DefaultOperator)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 			"the -d or --http-server flag.\n" +
 			"\n" +
 			"Searches by default use AND boolean syntax for all terms\n" +
+			" - use --default-operator=or to combine terms with OR\n" +
 			" - exact match using quotes \"find this\"\n" +
 			" - fuzzy match within 1 or 2 distance fuzzy~1 fuzzy~2\n" +
 			" - negate using NOT such as pride NOT prejudice\n" +
@@ -76,6 +77,12 @@ func main() {
 			}
 
 			cfg.SearchString = args
+
+			// Validate --default-operator
+			if _, err := cfg.ResolveDefaultOperator(); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
 
 			// Validate --profile
 			switch cfg.Profile {
@@ -283,6 +290,12 @@ func main() {
 		"profile",
 		"",
 		"ranking profile [balanced, precise, broad] — overrides --gravity, --noise, and --test-penalty when set",
+	)
+	flags.StringVar(
+		&cfg.DefaultOperator,
+		"default-operator",
+		"and",
+		"how to combine adjacent terms with no explicit AND/OR [and, or]. 'or' is useful for broad multi-keyword searches",
 	)
 	flags.StringVar(
 		&cfg.GravityIntent,

--- a/pkg/search/ast.go
+++ b/pkg/search/ast.go
@@ -24,6 +24,10 @@ func (n *AndNode) String() string { return fmt.Sprintf("(%s AND %s)", n.Left, n.
 type OrNode struct {
 	Left  Node
 	Right Node
+	// Implicit is true when this OR was created by combining adjacent terms
+	// under a default-or operator (rather than an explicit "OR" in the query).
+	// Filter hoisting only reaches through implicit OR groupings.
+	Implicit bool
 }
 
 func (n *OrNode) String() string { return fmt.Sprintf("(%s OR %s)", n.Left, n.Right) }

--- a/pkg/search/executor.go
+++ b/pkg/search/executor.go
@@ -52,6 +52,10 @@ func (se *SearchEngine) Search(query string, caseSensitive bool) (*SearchResult,
 		return nil, ErrInvalidQuery
 	}
 
+	// Filters constrain the whole query, so lift them out of any implicit OR
+	// grouping introduced by a default-or operator.
+	ast = HoistFilters(ast)
+
 	// 2. Transform
 	transformer := &Transformer{}
 	ast, transformNotices := transformer.TransformAST(ast)

--- a/pkg/search/hoist.go
+++ b/pkg/search/hoist.go
@@ -1,0 +1,66 @@
+package search
+
+// HoistFilters lifts metadata filters (path:, ext:, lang:, file:, complexity:,
+// etc.) out of implicit OR groupings so that they constrain the whole query
+// rather than being OR'd with individual terms.
+//
+// This matters when the default operator is OR: a query like
+//
+//	foo bar path:pkg
+//
+// parses as "foo OR bar OR path:pkg", but users expect the path filter to apply
+// to the entire query, i.e. "(foo OR bar) AND path:pkg". Hoisting rewrites it to
+// exactly that.
+//
+// Only implicit OR nodes (adjacent terms with no explicit operator) are
+// traversed. An explicit "foo OR path:x", a filter inside a NOT, and any AND
+// grouping are treated as opaque and left untouched, preserving the user's
+// stated intent. When the default operator is AND there are no implicit OR
+// nodes, so this pass returns the AST unchanged.
+func HoistFilters(node Node) Node {
+	if node == nil {
+		return nil
+	}
+	content, filters := hoistFilters(node)
+	for _, f := range filters {
+		if content == nil {
+			content = f
+		} else {
+			content = &AndNode{Left: content, Right: f}
+		}
+	}
+	return content
+}
+
+// hoistFilters recursively separates an implicit-OR subtree into its non-filter
+// content and the filters pulled out of it. A bare FilterNode becomes a hoisted
+// filter; any other node (explicit OR/AND groups, NOT, keywords, ...) is opaque
+// content that is not descended into.
+func hoistFilters(node Node) (content Node, filters []Node) {
+	switch n := node.(type) {
+	case *OrNode:
+		if !n.Implicit {
+			return n, nil
+		}
+		lc, lf := hoistFilters(n.Left)
+		rc, rf := hoistFilters(n.Right)
+		filters = append(lf, rf...)
+		return orJoin(lc, rc), filters
+	case *FilterNode:
+		return nil, []Node{n}
+	default:
+		return node, nil
+	}
+}
+
+// orJoin combines two (possibly nil) content nodes with an implicit OR.
+func orJoin(a, b Node) Node {
+	switch {
+	case a == nil:
+		return b
+	case b == nil:
+		return a
+	default:
+		return &OrNode{Left: a, Right: b, Implicit: true}
+	}
+}

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -193,7 +193,11 @@ func (p *Parser) parsePrefix() Node {
 	case LPAREN:
 		p.parenDepth++
 		p.nextToken() // Consume '('
-		node = p.parseExpression(0)
+		// Hoist filters within the group so they constrain the group's terms
+		// only. Wrapping them in an AndNode here also makes the group opaque to
+		// any outer hoist, so an explicit "(foo path:x) bar" keeps path:x scoped
+		// to foo rather than applying to bar as well.
+		node = HoistFilters(p.parseExpression(0))
 		if p.tok.Type == RPAREN {
 			p.parenDepth--
 			p.nextToken() // Consume ')'
@@ -291,7 +295,7 @@ func (p *Parser) parseImplicitExpression(left Node) Node {
 	// DO NOT consume a token here because there is no operator.
 	right := p.parseExpression(precedence)
 	if p.defaultOp == DefaultOr {
-		return &OrNode{Left: left, Right: right}
+		return &OrNode{Left: left, Right: right, Implicit: true}
 	}
 	return &AndNode{Left: left, Right: right}
 }

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -7,6 +7,17 @@ import (
 	"strings"
 )
 
+// DefaultOperator controls how adjacent terms with no explicit AND/OR between
+// them are combined (e.g. the query "cat dog fish").
+type DefaultOperator int
+
+const (
+	// DefaultAnd combines adjacent terms with AND (a file must contain all of them).
+	DefaultAnd DefaultOperator = iota
+	// DefaultOr combines adjacent terms with OR (a file may contain any of them).
+	DefaultOr
+)
+
 // Parser creates an AST from a stream of tokens.
 type Parser struct {
 	l          *Lexer
@@ -14,11 +25,24 @@ type Parser struct {
 	peekTok    Token
 	notices    []string
 	parenDepth int
+	defaultOp  DefaultOperator
+}
+
+// ParserOption configures optional Parser behaviour.
+type ParserOption func(*Parser)
+
+// WithDefaultOperator sets the operator used to combine adjacent terms that are
+// not separated by an explicit AND/OR. The default is DefaultAnd.
+func WithDefaultOperator(op DefaultOperator) ParserOption {
+	return func(p *Parser) { p.defaultOp = op }
 }
 
 // NewParser creates a new Parser.
-func NewParser(l *Lexer) *Parser {
+func NewParser(l *Lexer, opts ...ParserOption) *Parser {
 	p := &Parser{l: l}
+	for _, opt := range opts {
+		opt(p)
+	}
 	p.nextToken()
 	p.nextToken()
 	return p
@@ -93,8 +117,8 @@ func (p *Parser) parseExpression(precedence int) Node {
 				return left
 			}
 			left = p.parseInfixExpression(left)
-		case IDENTIFIER, PHRASE, REGEX, FUZZY, LPAREN, NOT: // An expression-starting token here means an implicit AND.
-			left = p.parseImplicitAndExpression(left)
+		case IDENTIFIER, PHRASE, REGEX, FUZZY, LPAREN, NOT: // An expression-starting token here means an implicit combination.
+			left = p.parseImplicitExpression(left)
 		default:
 			// If the token can't be part of an infix expression, stop.
 			return left
@@ -262,9 +286,12 @@ func (p *Parser) parseInfixExpression(left Node) Node {
 	return &OrNode{Left: left, Right: right}
 }
 
-func (p *Parser) parseImplicitAndExpression(left Node) Node {
+func (p *Parser) parseImplicitExpression(left Node) Node {
 	precedence := p.getPrecedence()
 	// DO NOT consume a token here because there is no operator.
 	right := p.parseExpression(precedence)
+	if p.defaultOp == DefaultOr {
+		return &OrNode{Left: left, Right: right}
+	}
 	return &AndNode{Left: left, Right: right}
 }

--- a/pkg/search/search_test.go
+++ b/pkg/search/search_test.go
@@ -207,6 +207,81 @@ func TestDefaultOperator(t *testing.T) {
 	}
 }
 
+func TestHoistFilters(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+		op    DefaultOperator
+		want  string
+	}{
+		{
+			"filter hoisted out of implicit OR",
+			"cat dog path:pkg", DefaultOr,
+			"((KEYWORD(cat) OR KEYWORD(dog)) AND FILTER(path = pkg))",
+		},
+		{
+			"filter in the middle is still hoisted",
+			"cat path:pkg dog", DefaultOr,
+			"((KEYWORD(cat) OR KEYWORD(dog)) AND FILTER(path = pkg))",
+		},
+		{
+			"multiple filters all hoisted",
+			"cat dog path:pkg ext:go", DefaultOr,
+			"(((KEYWORD(cat) OR KEYWORD(dog)) AND FILTER(path = pkg)) AND FILTER(ext = go))",
+		},
+		{
+			"only filters yields their conjunction",
+			"path:pkg ext:go", DefaultOr,
+			"(FILTER(path = pkg) AND FILTER(ext = go))",
+		},
+		{
+			"AND default is unchanged",
+			"cat dog path:pkg", DefaultAnd,
+			"((KEYWORD(cat) AND KEYWORD(dog)) AND FILTER(path = pkg))",
+		},
+		{
+			"explicit OR with a filter is left untouched",
+			"cat OR path:pkg", DefaultOr,
+			"(KEYWORD(cat) OR FILTER(path = pkg))",
+		},
+		{
+			"negated filter is not hoisted into a positive AND",
+			"cat NOT path:vendor", DefaultOr,
+			"(KEYWORD(cat) OR NOT FILTER(path = vendor))",
+		},
+		{
+			"filter in a paren group stays scoped to the group",
+			"(cat path:pkg) dog", DefaultOr,
+			"((KEYWORD(cat) AND FILTER(path = pkg)) OR KEYWORD(dog))",
+		},
+		{
+			"top-level filter still applies across a paren group",
+			"(cat dog) fish path:pkg", DefaultOr,
+			"(((KEYWORD(cat) OR KEYWORD(dog)) OR KEYWORD(fish)) AND FILTER(path = pkg))",
+		},
+		{
+			"filters scope independently inside and outside a group",
+			"(cat path:internal) dog ext:go", DefaultOr,
+			"(((KEYWORD(cat) AND FILTER(path = internal)) OR KEYWORD(dog)) AND FILTER(ext = go))",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lexer := NewLexer(strings.NewReader(tc.query))
+			parser := NewParser(lexer, WithDefaultOperator(tc.op))
+			ast, _ := parser.ParseQuery()
+			ast = HoistFilters(ast)
+			if ast == nil {
+				t.Fatalf("nil AST for %q", tc.query)
+			}
+			if got := ast.String(); got != tc.want {
+				t.Errorf("query %q: got %s, want %s", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTransformer(t *testing.T) {
 	se := NewSearchEngine(testDocs)
 	res, err := se.Search("complexity=high", false)

--- a/pkg/search/search_test.go
+++ b/pkg/search/search_test.go
@@ -177,6 +177,36 @@ func TestParserHealing(t *testing.T) {
 	}
 }
 
+func TestDefaultOperator(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+		op    DefaultOperator
+		want  string
+	}{
+		{"implicit AND (default)", "cat dog", DefaultAnd, "(KEYWORD(cat) AND KEYWORD(dog))"},
+		{"implicit OR", "cat dog", DefaultOr, "(KEYWORD(cat) OR KEYWORD(dog))"},
+		{"three terms AND", "cat dog fish", DefaultAnd, "((KEYWORD(cat) AND KEYWORD(dog)) AND KEYWORD(fish))"},
+		{"three terms OR", "cat dog fish", DefaultOr, "((KEYWORD(cat) OR KEYWORD(dog)) OR KEYWORD(fish))"},
+		{"explicit OR unaffected by AND default", "cat OR dog", DefaultAnd, "(KEYWORD(cat) OR KEYWORD(dog))"},
+		{"explicit AND unaffected by OR default", "cat AND dog", DefaultOr, "(KEYWORD(cat) AND KEYWORD(dog))"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lexer := NewLexer(strings.NewReader(tc.query))
+			parser := NewParser(lexer, WithDefaultOperator(tc.op))
+			ast, _ := parser.ParseQuery()
+			if ast == nil {
+				t.Fatalf("ParseQuery returned nil for %q", tc.query)
+			}
+			if got := ast.String(); got != tc.want {
+				t.Errorf("query %q: got %s, want %s", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTransformer(t *testing.T) {
 	se := NewSearchEngine(testDocs)
 	res, err := se.Search("complexity=high", false)

--- a/search.go
+++ b/search.go
@@ -43,8 +43,13 @@ func DoSearch(ctx context.Context, cfg *Config, query string, cache *SearchCache
 	}
 
 	// Parse query into AST
+	defaultOp, err := cfg.ResolveDefaultOperator()
+	if err != nil {
+		close(out)
+		return out, stats, err
+	}
 	lexer := search.NewLexer(strings.NewReader(query))
-	parser := search.NewParser(lexer)
+	parser := search.NewParser(lexer, search.WithDefaultOperator(defaultOp))
 	ast, _ := parser.ParseQuery()
 	if ast == nil {
 		close(out)

--- a/search.go
+++ b/search.go
@@ -56,6 +56,10 @@ func DoSearch(ctx context.Context, cfg *Config, query string, cache *SearchCache
 		return out, stats, nil
 	}
 
+	// Filters (path:, ext:, ...) constrain the whole query, so lift them out of
+	// any implicit OR grouping introduced by a default-or operator.
+	ast = search.HoistFilters(ast)
+
 	// Validate query term count
 	if cfg.MaxQueryTerms > 0 && search.CountAllTerms(ast) > cfg.MaxQueryTerms {
 		close(out)


### PR DESCRIPTION
### Summary

Added a configurable default query operator so bare multi-keyword searches (common from agents) can combine with OR instead of the default AND, which was too restrictive and often returned zero results.

`--default-operator=or` on the command line